### PR TITLE
Add themed sentence decks with illustrated prompts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,645 @@
-/* Vokabel-App Deluxe (vanilla JS, keine externen Libs) */
-const $ = (sel, el=document) => el.querySelector(sel);
-const $$ = (sel, el=document) => [...el.querySelectorAll(sel)];
+/* Russisch Vokabel-App Deluxe – moderne Landingpage, Themes & optionale Imports */
+const THEMES = {
+  midnight: {
+    label: 'Midnight Aurora',
+    description: 'Nordische Nacht, Schimmer der Polarlichter',
+    tone: 'dark',
+    icon: 'icon-moon',
+    music: 'https://cdn.pixabay.com/download/audio/2021/09/03/audio_3a8e8f302f.mp3?filename=ambient-astral-9644.mp3',
+    image: 'url("https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(135deg, #0b132e 0%, #1a3f6d 55%, #090b1c 100%)',
+    overlay: 'linear-gradient(160deg, rgba(14,31,68,0.3), rgba(0,0,0,0.6))',
+    vars: {
+      '--bg': '#050a1b',
+      '--bg-grad': 'radial-gradient(circle at 15% 20%, rgba(118,180,255,0.36), transparent 58%), radial-gradient(circle at 82% 10%, rgba(177,103,255,0.32), transparent 60%), #040715',
+      '--bg-texture': 'radial-gradient(circle, rgba(120,180,255,0.15) 0%, transparent 58%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.12) brightness(0.85)',
+      '--bg-art-opacity': '0.62',
+      '--fg': '#f4f7ff',
+      '--muted': '#9fb8df',
+      '--primary': '#82a7ff',
+      '--primary-2': '#98bcff',
+      '--danger': '#ff7a9b',
+      '--card': 'rgba(7,13,34,0.82)',
+      '--input-surface': 'rgba(12,20,44,0.82)',
+      '--card-border': 'rgba(130,165,255,0.38)',
+      '--input-border': 'rgba(130,165,255,0.32)',
+      '--border': 'rgba(255,255,255,0.12)',
+      '--accent': '#cbd9ff',
+      '--glass': 'rgba(6,10,28,0.64)',
+      '--shadow': '0 30px 65px rgba(3,6,18,0.6)'
+    }
+  },
+  imperial: {
+    label: 'Imperial Ballroom',
+    description: 'Goldene Details, klassisches St. Petersburg',
+    tone: 'light',
+    icon: 'icon-palace',
+    music: 'https://cdn.pixabay.com/download/audio/2022/03/15/audio_1aa1aa811d.mp3?filename=grand-entrance-20551.mp3',
+    image: 'url("https://images.unsplash.com/photo-1529429617124-aee0a37c56b3?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(135deg, #f6e7d3 0%, #d7b06a 55%, #a0742a 100%)',
+    overlay: 'linear-gradient(140deg, rgba(168,118,50,0.4), rgba(255,255,255,0.48))',
+    vars: {
+      '--bg': '#f4e9da',
+      '--bg-grad': 'radial-gradient(circle at 20% 15%, rgba(255,214,153,0.55), transparent 58%), radial-gradient(circle at 80% 8%, rgba(197,163,107,0.4), transparent 60%), #f6ede0',
+      '--bg-texture': 'radial-gradient(circle, rgba(255,228,180,0.16) 0%, transparent 58%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1529429617124-aee0a37c56b3?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.05) brightness(1.05)',
+      '--bg-art-opacity': '0.38',
+      '--fg': '#2f1d0e',
+      '--muted': '#7a5837',
+      '--primary': '#b17535',
+      '--primary-2': '#d29a52',
+      '--danger': '#c65151',
+      '--card': 'rgba(255,250,244,0.82)',
+      '--input-surface': 'rgba(255,255,255,0.85)',
+      '--card-border': 'rgba(185,132,66,0.4)',
+      '--input-border': 'rgba(136,98,52,0.28)',
+      '--border': 'rgba(120,82,43,0.24)',
+      '--accent': '#f0c27d',
+      '--glass': 'rgba(255,248,236,0.72)',
+      '--shadow': '0 24px 50px rgba(147,110,58,0.32)'
+    }
+  },
+  birch: {
+    label: 'Birkenwald',
+    description: 'Frische Morgenluft & russische Natur',
+    tone: 'light',
+    icon: 'icon-forest',
+    music: 'https://cdn.pixabay.com/download/audio/2021/11/23/audio_33aebca41a.mp3?filename=foggy-forest-ambient-9833.mp3',
+    image: 'url("https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(140deg, #0f5b4c 0%, #4fa37e 60%, #c8f3d4 100%)',
+    overlay: 'linear-gradient(160deg, rgba(14,63,54,0.35), rgba(255,255,255,0.35))',
+    vars: {
+      '--bg': '#0f2f2a',
+      '--bg-grad': 'radial-gradient(circle at 80% 10%, rgba(110,200,160,0.45), transparent 58%), radial-gradient(circle at 15% 90%, rgba(60,180,150,0.35), transparent 60%), #0c221f',
+      '--bg-texture': 'radial-gradient(circle, rgba(200,255,220,0.12) 0%, transparent 60%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.05) brightness(0.95)',
+      '--bg-art-opacity': '0.46',
+      '--fg': '#f4fff5',
+      '--muted': '#9ec7b0',
+      '--primary': '#4fba9c',
+      '--primary-2': '#74d5b7',
+      '--danger': '#f46d6d',
+      '--card': 'rgba(10,32,28,0.82)',
+      '--input-surface': 'rgba(14,40,34,0.78)',
+      '--card-border': 'rgba(120,210,170,0.35)',
+      '--input-border': 'rgba(110,210,170,0.32)',
+      '--border': 'rgba(140,200,170,0.28)',
+      '--accent': '#8be5c5',
+      '--glass': 'rgba(12,36,30,0.68)',
+      '--shadow': '0 26px 52px rgba(2,22,18,0.48)'
+    }
+  },
+  velvet: {
+    label: 'Velvet Theatre',
+    description: 'Burgunder Vorhänge & warme Kerzen',
+    tone: 'dark',
+    icon: 'icon-masks',
+    music: 'https://cdn.pixabay.com/download/audio/2021/09/13/audio_94c5a12cfa.mp3?filename=velvet-9679.mp3',
+    image: 'url("https://images.unsplash.com/photo-1505843513577-22bb7d21e455?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(135deg, #3d0f1d 0%, #742235 50%, #19060d 100%)',
+    overlay: 'linear-gradient(160deg, rgba(125,41,64,0.45), rgba(0,0,0,0.6))',
+    vars: {
+      '--bg': '#16050c',
+      '--bg-grad': 'radial-gradient(circle at 75% 10%, rgba(198,88,120,0.5), transparent 58%), radial-gradient(circle at 10% 80%, rgba(90,26,44,0.42), transparent 60%), #0f0308',
+      '--bg-texture': 'radial-gradient(circle, rgba(255,214,214,0.1) 0%, transparent 60%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1505843513577-22bb7d21e455?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.1) brightness(0.85)',
+      '--bg-art-opacity': '0.58',
+      '--fg': '#fbe9f0',
+      '--muted': '#c49aa8',
+      '--primary': '#d66280',
+      '--primary-2': '#f07ea0',
+      '--danger': '#f76a6a',
+      '--card': 'rgba(40,10,22,0.85)',
+      '--input-surface': 'rgba(40,12,26,0.82)',
+      '--card-border': 'rgba(214,98,128,0.4)',
+      '--input-border': 'rgba(214,98,128,0.32)',
+      '--border': 'rgba(214,98,128,0.25)',
+      '--accent': '#ff9dbd',
+      '--glass': 'rgba(36,8,20,0.72)',
+      '--shadow': '0 28px 54px rgba(39,7,17,0.55)'
+    }
+  },
+  sunset: {
+    label: 'Sunset Steppe',
+    description: 'Weite Horizonte & warme Pastelltöne',
+    tone: 'light',
+    icon: 'icon-sunrise',
+    music: 'https://cdn.pixabay.com/download/audio/2022/03/22/audio_5ba6c8efcc.mp3?filename=sunset-reverie-20962.mp3',
+    image: 'url("https://images.unsplash.com/photo-1470509037663-253afd7f0f0b?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(135deg, #ffb47d 0%, #ff6f91 45%, #1f1c47 100%)',
+    overlay: 'linear-gradient(180deg, rgba(255,119,93,0.38), rgba(18,13,46,0.6))',
+    vars: {
+      '--bg': '#1e1635',
+      '--bg-grad': 'radial-gradient(circle at 20% 10%, rgba(255,196,120,0.58), transparent 55%), radial-gradient(circle at 80% 5%, rgba(206,98,171,0.45), transparent 60%), #1a1531',
+      '--bg-texture': 'radial-gradient(circle, rgba(255,200,150,0.14) 0%, transparent 60%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1470509037663-253afd7f0f0b?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.08) brightness(0.9)',
+      '--bg-art-opacity': '0.5',
+      '--fg': '#fff4f2',
+      '--muted': '#e2b5ad',
+      '--primary': '#ff7c8d',
+      '--primary-2': '#ff9fa7',
+      '--danger': '#ff5c72',
+      '--card': 'rgba(34,20,54,0.85)',
+      '--input-surface': 'rgba(38,24,60,0.78)',
+      '--card-border': 'rgba(255,140,160,0.35)',
+      '--input-border': 'rgba(255,140,160,0.32)',
+      '--border': 'rgba(255,158,180,0.22)',
+      '--accent': '#ffd1a1',
+      '--glass': 'rgba(30,20,53,0.7)',
+      '--shadow': '0 26px 52px rgba(12,9,26,0.55)'
+    }
+  },
+  midnightSun: {
+    label: 'Midnight Sun',
+    description: 'Nordisches Licht zwischen Tag und Nacht',
+    tone: 'dark',
+    icon: 'icon-compass-star',
+    music: 'https://cdn.pixabay.com/download/audio/2022/03/07/audio_0d8c789a58.mp3?filename=northern-lights-20268.mp3',
+    image: 'url("https://images.unsplash.com/photo-1470770841072-f978cf4d019e?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(135deg, #17375e 0%, #2f6c88 45%, #f2c86a 100%)',
+    overlay: 'linear-gradient(160deg, rgba(16,48,88,0.4), rgba(255,206,122,0.45))',
+    vars: {
+      '--bg': '#102132',
+      '--bg-grad': 'radial-gradient(circle at 15% 20%, rgba(118,180,255,0.45), transparent 58%), radial-gradient(circle at 75% 10%, rgba(255,207,116,0.42), transparent 60%), #0b1829',
+      '--bg-texture': 'radial-gradient(circle, rgba(255,233,170,0.14) 0%, transparent 60%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1470770841072-f978cf4d019e?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.08) brightness(0.92)',
+      '--bg-art-opacity': '0.48',
+      '--fg': '#f3fbff',
+      '--muted': '#a2bed4',
+      '--primary': '#6bc4ff',
+      '--primary-2': '#8cd8ff',
+      '--danger': '#ff7a7a',
+      '--card': 'rgba(12,31,52,0.82)',
+      '--input-surface': 'rgba(16,32,52,0.8)',
+      '--card-border': 'rgba(107,196,255,0.38)',
+      '--input-border': 'rgba(107,196,255,0.32)',
+      '--border': 'rgba(255,255,255,0.12)',
+      '--accent': '#ffd07a',
+      '--glass': 'rgba(11,26,42,0.7)',
+      '--shadow': '0 24px 50px rgba(8,22,38,0.55)'
+    }
+  },
+  winterPalace: {
+    label: 'Winter Palace',
+    description: 'Eisblaues Petersburg & barocker Glanz',
+    tone: 'cool',
+    icon: 'icon-snowflake',
+    music: 'https://cdn.pixabay.com/download/audio/2022/02/23/audio_d5d6b2e2ef.mp3?filename=royal-waltz-11075.mp3',
+    image: 'url("https://images.unsplash.com/photo-1548777123-ec5aa862c16a?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(140deg, #0e3b5e 0%, #3ba0c9 55%, #c8f3ff 100%)',
+    overlay: 'linear-gradient(160deg, rgba(16,84,122,0.32), rgba(255,255,255,0.4))',
+    vars: {
+      '--bg': '#061a2c',
+      '--bg-grad': 'radial-gradient(circle at 78% 12%, rgba(120,200,255,0.42), transparent 60%), radial-gradient(circle at 12% 88%, rgba(40,130,185,0.35), transparent 62%), #04121f',
+      '--bg-texture': 'radial-gradient(circle, rgba(180,230,255,0.16) 0%, transparent 60%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1548777123-ec5aa862c16a?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.05) brightness(0.9)',
+      '--bg-art-opacity': '0.52',
+      '--fg': '#e9f6ff',
+      '--muted': '#9bc4db',
+      '--primary': '#78c9ff',
+      '--primary-2': '#9bdfff',
+      '--danger': '#ff7fa1',
+      '--card': 'rgba(10,34,48,0.82)',
+      '--input-surface': 'rgba(16,42,60,0.8)',
+      '--card-border': 'rgba(120,200,255,0.38)',
+      '--input-border': 'rgba(120,200,255,0.34)',
+      '--border': 'rgba(132,190,220,0.3)',
+      '--accent': '#b9f1ff',
+      '--glass': 'rgba(6,24,40,0.7)',
+      '--shadow': '0 30px 60px rgba(4,18,36,0.55)'
+    }
+  },
+  porcelain: {
+    label: 'Porzellan Garten',
+    description: 'Pastellblüten & zarte Ornamentik',
+    tone: 'light',
+    icon: 'icon-porcelain',
+    music: 'https://cdn.pixabay.com/download/audio/2022/02/16/audio_7a82c20a5c.mp3?filename=tea-room-10757.mp3',
+    image: 'url("https://images.unsplash.com/photo-1521120098170-1e1c3f58c6f8?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(145deg, #f7c3d0 0%, #f5e6ff 55%, #9dc9ff 100%)',
+    overlay: 'linear-gradient(160deg, rgba(250,210,230,0.45), rgba(120,160,255,0.3))',
+    vars: {
+      '--bg': '#f8edf3',
+      '--bg-grad': 'radial-gradient(circle at 18% 20%, rgba(255,200,220,0.55), transparent 58%), radial-gradient(circle at 82% 6%, rgba(176,200,255,0.45), transparent 60%), #f6f0f8',
+      '--bg-texture': 'radial-gradient(circle, rgba(255,210,235,0.16) 0%, transparent 58%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1521120098170-1e1c3f58c6f8?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.08) brightness(1.05)',
+      '--bg-art-opacity': '0.35',
+      '--fg': '#2f2a3a',
+      '--muted': '#7c6e8f',
+      '--primary': '#c768a1',
+      '--primary-2': '#de89ba',
+      '--danger': '#d45b7c',
+      '--card': 'rgba(255,252,255,0.78)',
+      '--input-surface': 'rgba(255,255,255,0.88)',
+      '--card-border': 'rgba(215,160,210,0.35)',
+      '--input-border': 'rgba(160,140,190,0.26)',
+      '--border': 'rgba(164,140,190,0.22)',
+      '--accent': '#9ec8ff',
+      '--glass': 'rgba(255,248,255,0.72)',
+      '--shadow': '0 26px 52px rgba(172,148,196,0.28)'
+    }
+  },
+  volga: {
+    label: 'Volga Dawn',
+    description: 'Morgendunst über stillen Flussufern',
+    tone: 'mist',
+    icon: 'icon-river',
+    music: 'https://cdn.pixabay.com/download/audio/2021/10/31/audio_dba7f2a7bc.mp3?filename=gentle-river-ambient-9603.mp3',
+    image: 'url("https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(140deg, #1d2d44 0%, #3b6c7a 55%, #b3d9d7 100%)',
+    overlay: 'linear-gradient(160deg, rgba(32,78,108,0.4), rgba(196,220,215,0.35))',
+    vars: {
+      '--bg': '#0d1a26',
+      '--bg-grad': 'radial-gradient(circle at 72% 12%, rgba(120,180,200,0.45), transparent 60%), radial-gradient(circle at 18% 86%, rgba(70,140,160,0.38), transparent 62%), #08121d',
+      '--bg-texture': 'radial-gradient(circle, rgba(160,210,220,0.16) 0%, transparent 60%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.02) brightness(0.9)',
+      '--bg-art-opacity': '0.5',
+      '--fg': '#ecf4f7',
+      '--muted': '#9eb7c3',
+      '--primary': '#5bb5c5',
+      '--primary-2': '#7ad0d6',
+      '--danger': '#ff7f86',
+      '--card': 'rgba(12,32,44,0.82)',
+      '--input-surface': 'rgba(18,36,48,0.8)',
+      '--card-border': 'rgba(120,180,200,0.36)',
+      '--input-border': 'rgba(120,180,200,0.32)',
+      '--border': 'rgba(150,200,210,0.22)',
+      '--accent': '#b7e6e0',
+      '--glass': 'rgba(10,28,40,0.68)',
+      '--shadow': '0 28px 58px rgba(5,16,26,0.55)'
+    }
+  },
+  troika: {
+    label: 'Troika Trail',
+    description: 'Winterliche Kutschfahrt durch den Schnee',
+    tone: 'frost',
+    icon: 'icon-troika',
+    music: 'https://cdn.pixabay.com/download/audio/2021/12/14/audio_2b31a8b6ce.mp3?filename=winter-carriage-ambient-9959.mp3',
+    image: 'url("https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80")',
+    preview: 'linear-gradient(140deg, #1a2740 0%, #4f7aa0 55%, #ffffff 100%)',
+    overlay: 'linear-gradient(160deg, rgba(20,40,70,0.45), rgba(255,255,255,0.5))',
+    vars: {
+      '--bg': '#0a1524',
+      '--bg-grad': 'radial-gradient(circle at 20% 15%, rgba(120,170,210,0.45), transparent 60%), radial-gradient(circle at 82% 10%, rgba(200,220,255,0.42), transparent 62%), #050e1a',
+      '--bg-texture': 'radial-gradient(circle, rgba(200,230,255,0.14) 0%, transparent 60%)',
+      '--bg-art': 'url("https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=2000&q=80")',
+      '--bg-art-position': 'center center',
+      '--bg-art-size': 'cover',
+      '--bg-art-filter': 'saturate(1.05) brightness(0.92)',
+      '--bg-art-opacity': '0.55',
+      '--fg': '#f0f6ff',
+      '--muted': '#a9bfd6',
+      '--primary': '#6faee8',
+      '--primary-2': '#8bc5f2',
+      '--danger': '#ff7284',
+      '--card': 'rgba(12,30,50,0.8)',
+      '--input-surface': 'rgba(16,36,56,0.8)',
+      '--card-border': 'rgba(140,190,230,0.36)',
+      '--input-border': 'rgba(140,190,230,0.32)',
+      '--border': 'rgba(160,200,230,0.22)',
+      '--accent': '#d5f0ff',
+      '--glass': 'rgba(8,20,36,0.7)',
+      '--shadow': '0 28px 56px rgba(6,14,26,0.55)'
+    }
+  }
+};
+
+const GRADE_INFO = {
+  grade7: {
+    label: 'Klasse 7',
+    description: 'Dialog 1 – Alltag, Schule & Freunde',
+    icon: 'icon-book',
+    ribbon: 'linear-gradient(140deg, rgba(120,160,255,0.5), transparent 70%)'
+  },
+  grade8: {
+    label: 'Klasse 8',
+    description: 'Dialog 2 – Unterwegs, Reisen & Kultur',
+    icon: 'icon-compass',
+    ribbon: 'linear-gradient(140deg, rgba(255,168,120,0.48), transparent 70%)'
+  },
+  grade9: {
+    label: 'Klasse 9',
+    description: 'Dialog 3 – Zukunft, Umwelt & Medien',
+    icon: 'icon-globe',
+    ribbon: 'linear-gradient(140deg, rgba(140,230,190,0.48), transparent 70%)'
+  },
+  grade10: {
+    label: 'Klasse 10',
+    description: 'Dialog 4 – Gesellschaft, Politik & Kultur',
+    icon: 'icon-laurel',
+    ribbon: 'linear-gradient(140deg, rgba(255,210,140,0.52), transparent 70%)'
+  }
+};
+
+
+const CATEGORY_ART = {
+  'Freunde treffen': {
+    image: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1600&q=80',
+    accent: '#74c0ff'
+  },
+  'Im Klassenzimmer': {
+    image: 'https://images.unsplash.com/photo-1523580494863-6f3031224c94?auto=format&fit=crop&w=1600&q=80',
+    accent: '#ffd166'
+  },
+  'Im Café': {
+    image: 'https://images.unsplash.com/photo-1504754524776-8f4f37790ca0?auto=format&fit=crop&w=1600&q=80',
+    accent: '#ff9f68'
+  },
+  'Zu Hause bei der Familie': {
+    image: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=1600&q=80',
+    accent: '#f4a261'
+  },
+  'Freizeit planen': {
+    image: 'https://images.unsplash.com/photo-1529158062015-cad636e69505?auto=format&fit=crop&w=1600&q=80',
+    accent: '#9d4edd'
+  },
+  'Unterwegs in der Stadt': {
+    image: 'https://images.unsplash.com/photo-1470123808288-1e59739f54da?auto=format&fit=crop&w=1600&q=80',
+    accent: '#2ec4b6'
+  },
+  'Stadtrundfahrt in Moskau': {
+    image: 'https://images.unsplash.com/photo-1505843513577-22bb7d21e455?auto=format&fit=crop&w=1600&q=80',
+    accent: '#ff6f91'
+  },
+  'Reisevorbereitung': {
+    image: 'https://images.unsplash.com/photo-1518684079-3c830dcef090?auto=format&fit=crop&w=1600&q=80',
+    accent: '#48bfe3'
+  },
+  'Im Gastfamilienhaus': {
+    image: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80',
+    accent: '#ffb5a7'
+  },
+  'Kultur & Theater': {
+    image: 'https://images.unsplash.com/photo-1523731407965-2430cd12f5e4?auto=format&fit=crop&w=1600&q=80',
+    accent: '#b5179e'
+  },
+  'Kulinarische Pause': {
+    image: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=1600&q=80',
+    accent: '#f77f00'
+  },
+  'Projektarbeit Schule': {
+    image: 'https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=1600&q=80',
+    accent: '#4361ee'
+  },
+  'Klimaprojekt': {
+    image: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80',
+    accent: '#2ec4b6'
+  },
+  'Medienlabor': {
+    image: 'https://images.unsplash.com/photo-1510074377623-8cf13fb86c08?auto=format&fit=crop&w=1600&q=80',
+    accent: '#ffb703'
+  },
+  'Freiwilligenarbeit': {
+    image: 'https://images.unsplash.com/photo-1526256262350-7da7584cf5eb?auto=format&fit=crop&w=1600&q=80',
+    accent: '#06d6a0'
+  },
+  'Technologie-Workshop': {
+    image: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1600&q=80',
+    accent: '#4895ef'
+  },
+  'Berufsberatung': {
+    image: 'https://images.unsplash.com/photo-1521791136064-7986c2920216?auto=format&fit=crop&w=1600&q=80',
+    accent: '#ffba08'
+  },
+  'Internationale Begegnung': {
+    image: 'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=1600&q=80',
+    accent: '#ef476f'
+  },
+  'Gesellschaftliche Debatte': {
+    image: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80',
+    accent: '#f94144'
+  },
+  'Politisches Planspiel': {
+    image: 'https://images.unsplash.com/photo-1530031669806-38fef3f0d1cf?auto=format&fit=crop&w=1600&q=80',
+    accent: '#577590'
+  },
+  'Wirtschaft & Innovation': {
+    image: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1600&q=80',
+    accent: '#43aa8b'
+  },
+  'Kulturelles Symposium': {
+    image: 'https://images.unsplash.com/photo-1478144592103-25e218a04891?auto=format&fit=crop&w=1600&q=80',
+    accent: '#f3722c'
+  },
+  'Medienkritik': {
+    image: 'https://images.unsplash.com/photo-1515169067865-5387ec356754?auto=format&fit=crop&w=1600&q=80',
+    accent: '#4d908e'
+  },
+  'Zukunftsvisionen': {
+    image: 'https://images.unsplash.com/photo-1482192597420-4817fdd7e8b0?auto=format&fit=crop&w=1600&q=80',
+    accent: '#9d4edd'
+  }
+};
+
+const BUILT_IN_WORDS = {
+  grade7: [
+    { id: 'g7-001', cat: 'Freunde treffen', ru: 'Привет, давай встретимся у метро в пять часов.', de: 'Hallo, lass uns um fünf Uhr an der U-Bahn treffen.' },
+    { id: 'g7-002', cat: 'Freunde treffen', ru: 'Я купил билеты в кино, приходи пораньше, чтобы успеть за попкорном.', de: 'Ich habe Kinokarten gekauft, komm etwas früher, damit wir Popcorn schaffen.' },
+    { id: 'g7-003', cat: 'Freunde treffen', ru: 'После уроков пойдём гулять вдоль набережной, там сегодня красиво.', de: 'Nach dem Unterricht gehen wir an der Promenade spazieren, dort ist es heute schön.' },
+    { id: 'g7-004', cat: 'Freunde treffen', ru: 'Может быть, сыграем в настольные игры у меня дома вечером?', de: 'Vielleicht spielen wir abends bei mir zuhause Brettspiele?' },
+    { id: 'g7-005', cat: 'Freunde treffen', ru: 'Напиши в чат, если задержишься, мы подождём у фонтана.', de: 'Schreib in den Chat, wenn du dich verspätest, wir warten am Brunnen.' },
+    { id: 'g7-006', cat: 'Im Klassenzimmer', ru: 'Учитель просил нас подготовить короткую презентацию о своём хобби.', de: 'Der Lehrer bat uns, eine kurze Präsentation über unser Hobby vorzubereiten.' },
+    { id: 'g7-007', cat: 'Im Klassenzimmer', ru: 'Ты можешь одолжить мне тетрадь по истории? Я пропустил прошлый урок.', de: 'Kannst du mir das Geschichtsheft leihen? Ich habe die letzte Stunde verpasst.' },
+    { id: 'g7-008', cat: 'Im Klassenzimmer', ru: 'На перемене пойдём к библиотеке, там открылась новая выставка.', de: 'In der Pause gehen wir zur Bibliothek, dort hat eine neue Ausstellung eröffnet.' },
+    { id: 'g7-009', cat: 'Im Klassenzimmer', ru: 'Контрольная работа перенесена на пятницу, так что есть время повторить.', de: 'Die Klassenarbeit wurde auf Freitag verschoben, also haben wir Zeit zu wiederholen.' },
+    { id: 'g7-010', cat: 'Im Klassenzimmer', ru: 'После звонка не забудь отдать учителю подписанный дневник.', de: 'Vergiss nach dem Klingeln nicht, dem Lehrer das unterschriebene Tagebuch zu geben.' },
+    { id: 'g7-011', cat: 'Im Café', ru: 'Здравствуйте, нам, пожалуйста, два какао и один сырник со сметаной.', de: 'Guten Tag, für uns bitte zwei Kakao und einen Syrnik mit Sauerrahm.' },
+    { id: 'g7-012', cat: 'Im Café', ru: 'У вас есть свободный столик у окна? Мы хотим любоваться улицей.', de: 'Haben Sie einen freien Tisch am Fenster? Wir möchten die Straße betrachten.' },
+    { id: 'g7-013', cat: 'Im Café', ru: 'Можно добавить в чай немного мёда, он слишком горячий.', de: 'Können Sie etwas Honig in den Tee geben? Er ist zu heiß.' },
+    { id: 'g7-014', cat: 'Im Café', ru: 'Принесите счёт, пожалуйста, мы торопимся на спектакль.', de: 'Bringen Sie die Rechnung bitte, wir beeilen uns zum Theater.' },
+    { id: 'g7-015', cat: 'Im Café', ru: 'Давай поделим десерт поровну, торт выглядит слишком вкусным.', de: 'Lass uns das Dessert gerecht teilen, der Kuchen sieht zu lecker aus.' },
+    { id: 'g7-016', cat: 'Zu Hause bei der Familie', ru: 'Мама просит тебя помочь накрыть на стол к ужину.', de: 'Mama bittet dich, beim Tischdecken fürs Abendessen zu helfen.' },
+    { id: 'g7-017', cat: 'Zu Hause bei der Familie', ru: 'Бабушка рассказывает историю о своей школьной жизни, слушай внимательно.', de: 'Die Großmutter erzählt eine Geschichte über ihre Schulzeit, hör aufmerksam zu.' },
+    { id: 'g7-018', cat: 'Zu Hause bei der Familie', ru: 'Не забудь покормить кота и поменять ему воду.', de: 'Vergiss nicht, die Katze zu füttern und ihr Wasser zu wechseln.' },
+    { id: 'g7-019', cat: 'Zu Hause bei der Familie', ru: 'Давай вместе подготовим гостиную к приходу друзей.', de: 'Lass uns gemeinsam das Wohnzimmer für die Freunde vorbereiten.' },
+    { id: 'g7-020', cat: 'Zu Hause bei der Familie', ru: 'Папа установил новую полку, туда можно поставить книги по русскому.', de: 'Papa hat ein neues Regal angebracht, dort können wir die Russisch-Bücher hinstellen.' },
+    { id: 'g7-021', cat: 'Freizeit planen', ru: 'После школы мы хотим покататься на роликах в парке.', de: 'Nach der Schule wollen wir im Park Inlineskates fahren.' },
+    { id: 'g7-022', cat: 'Freizeit planen', ru: 'Запишись на мастер-класс по рисованию, он начнётся в субботу.', de: 'Melde dich für den Zeichenworkshop an, er beginnt am Samstag.' },
+    { id: 'g7-023', cat: 'Freizeit planen', ru: 'В субботу состоится школьный концерт, не забудь пригласить друзей.', de: 'Am Samstag findet das Schulkonzert statt, vergiss nicht deine Freunde einzuladen.' },
+    { id: 'g7-024', cat: 'Freizeit planen', ru: 'Я скачал новое приложение для изучения языков, давай попробуем вместе.', de: 'Ich habe eine neue Sprachlern-App heruntergeladen, lass sie uns gemeinsam ausprobieren.' },
+    { id: 'g7-025', cat: 'Freizeit planen', ru: 'Если будет дождь, устроим дома киновечер с русскими субтитрами.', de: 'Wenn es regnet, machen wir zuhause einen Filmabend mit russischen Untertiteln.' },
+    { id: 'g7-026', cat: 'Unterwegs in der Stadt', ru: 'Автобус задерживается, поэтому поедем на метро до центра.', de: 'Der Bus verspätet sich, daher fahren wir mit der U-Bahn in die Innenstadt.' },
+    { id: 'g7-027', cat: 'Unterwegs in der Stadt', ru: 'Спроси у прохожего, где ближайший книжный магазин.', de: 'Frag einen Passanten, wo der nächste Buchladen ist.' },
+    { id: 'g7-028', cat: 'Unterwegs in der Stadt', ru: 'На площади проходит ярмарка, там продают ремёсла и пирожки.', de: 'Auf dem Platz findet ein Markt statt, dort gibt es Handwerk und Piroggen.' },
+    { id: 'g7-029', cat: 'Unterwegs in der Stadt', ru: 'Давай сделаем фото на фоне старинного театра.', de: 'Lass uns ein Foto vor dem alten Theater machen.' },
+    { id: 'g7-030', cat: 'Unterwegs in der Stadt', ru: 'Перед выходом проверим расписание трамваев на табло.', de: 'Vor dem Losgehen prüfen wir den Straßenbahnfahrplan auf der Anzeigetafel.' }
+  ],
+  grade8: [
+    { id: 'g8-001', cat: 'Stadtrundfahrt in Moskau', ru: 'Добро пожаловать на экскурсию, наш автобус отправляется от Кремля через пять минут.', de: 'Willkommen zur Stadtrundfahrt, unser Bus fährt in fünf Minuten vom Kreml ab.' },
+    { id: 'g8-002', cat: 'Stadtrundfahrt in Moskau', ru: 'Посмотрите направо, там открывается вид на Москва-реку и парк Зарядье.', de: 'Schaut nach rechts, dort eröffnet sich der Blick auf die Moskwa und den Park Sarjadje.' },
+    { id: 'g8-003', cat: 'Stadtrundfahrt in Moskau', ru: 'Мы сделаем остановку у Третьяковской галереи, чтобы вы могли сделать фотографии.', de: 'Wir machen einen Halt an der Tretjakow-Galerie, damit ihr Fotos machen könnt.' },
+    { id: 'g8-004', cat: 'Stadtrundfahrt in Moskau', ru: 'Не отходите далеко от группы, в центре много туристов и легко потеряться.', de: 'Entfernt euch nicht weit von der Gruppe, im Zentrum gibt es viele Touristen und man kann sich leicht verirren.' },
+    { id: 'g8-005', cat: 'Stadtrundfahrt in Moskau', ru: 'После экскурсии у вас будет свободный час для сувениров на Арбате.', de: 'Nach der Führung habt ihr eine freie Stunde für Souvenirs auf dem Arbat.' },
+    { id: 'g8-006', cat: 'Reisevorbereitung', ru: 'Проверим, все ли взяли загранпаспорт и страховой полис.', de: 'Wir prüfen, ob alle den Reisepass und die Versicherungspolice dabeihaben.' },
+    { id: 'g8-007', cat: 'Reisevorbereitung', ru: 'Я отправил маршрут в общий чат, распечатайте карту на всякий случай.', de: 'Ich habe die Route im Gruppenchat geschickt, druckt zur Sicherheit eine Karte aus.' },
+    { id: 'g8-008', cat: 'Reisevorbereitung', ru: 'Не забудь зарядное устройство и переходник для розетки.', de: 'Vergiss das Ladegerät und den Steckdosenadapter nicht.' },
+    { id: 'g8-009', cat: 'Reisevorbereitung', ru: 'Мы договаривались встретиться на вокзале за полчаса до отправления поезда.', de: 'Wir wollten uns eine halbe Stunde vor Abfahrt des Zuges am Bahnhof treffen.' },
+    { id: 'g8-010', cat: 'Reisevorbereitung', ru: 'Положи в ручную кладь тёплую кофту, в поезде ночью бывает прохладно.', de: 'Packe einen warmen Pullover ins Handgepäck, nachts wird es im Zug kühl.' },
+    { id: 'g8-011', cat: 'Im Gastfamilienhaus', ru: 'Хозяйка приготовила борщ, обязательно похвали её кулинарные таланты.', de: 'Die Gastgeberin hat Borschtsch gekocht, lobe unbedingt ihre Kochkünste.' },
+    { id: 'g8-012', cat: 'Im Gastfamilienhaus', ru: 'Не забудь снять обувь у входа, в их доме так принято.', de: 'Vergiss nicht, am Eingang die Schuhe auszuziehen, so ist es in ihrem Haus üblich.' },
+    { id: 'g8-013', cat: 'Im Gastfamilienhaus', ru: 'Спросим, чем мы можем помочь накрыть к чаю и достанем варенье.', de: 'Fragen wir, wie wir beim Teetisch helfen können, und holen wir die Marmelade.' },
+    { id: 'g8-014', cat: 'Im Gastfamilienhaus', ru: 'Вечером семья предлагает сыграть в настольные игры, согласись обязательно.', de: 'Am Abend schlägt die Familie vor, Brettspiele zu spielen – sag unbedingt zu.' },
+    { id: 'g8-015', cat: 'Im Gastfamilienhaus', ru: 'Если что-то непонятно, вежливо переспроси, они любят объяснять.', de: 'Wenn etwas unklar ist, frag höflich nach, sie erklären es gern.' },
+    { id: 'g8-016', cat: 'Kultur & Theater', ru: 'Перед спектаклем мы обсудим сюжет пьесы, чтобы легче было понимать.', de: 'Vor dem Stück besprechen wir die Handlung, damit das Verständnis leichter fällt.' },
+    { id: 'g8-017', cat: 'Kultur & Theater', ru: 'В театре нужно выключить телефоны и говорить шёпотом.', de: 'Im Theater müssen die Handys ausgeschaltet und nur geflüstert werden.' },
+    { id: 'g8-018', cat: 'Kultur & Theater', ru: 'После представления у нас встреча с актёром, подготовьте вопросы.', de: 'Nach der Vorstellung haben wir ein Treffen mit einem Schauspieler, bereitet Fragen vor.' },
+    { id: 'g8-019', cat: 'Kultur & Theater', ru: 'Обратите внимание на костюмы, они воссоздают моду XIX века.', de: 'Achtet auf die Kostüme, sie rekonstruieren die Mode des 19. Jahrhunderts.' },
+    { id: 'g8-020', cat: 'Kultur & Theater', ru: 'В программке есть краткая биография автора, прочитайте её в антракте.', de: 'Im Programmheft steht eine kurze Biografie des Autors, lest sie in der Pause.' },
+    { id: 'g8-021', cat: 'Kulinarische Pause', ru: 'Закажем блины с творогом и мятный чай, это фирменное блюдо.', de: 'Bestellen wir Blini mit Quark und Minztee, das ist eine Spezialität.' },
+    { id: 'g8-022', cat: 'Kulinarische Pause', ru: 'Спросите официанта, можно ли расплатиться картой МИР.', de: 'Fragt den Kellner, ob man mit der MIR-Karte bezahlen kann.' },
+    { id: 'g8-023', cat: 'Kulinarische Pause', ru: 'Если будет очередь, предложи занять столик на улице под зонтом.', de: 'Falls es eine Schlange gibt, schlage vor, draußen unter dem Schirm Platz zu nehmen.' },
+    { id: 'g8-024', cat: 'Kulinarische Pause', ru: 'Не забудь оставить чаевые, сервис был очень доброжелательный.', de: 'Vergiss nicht, Trinkgeld zu geben, der Service war sehr freundlich.' },
+    { id: 'g8-025', cat: 'Kulinarische Pause', ru: 'Сфотографируем витрину с пирожными для школьного блога.', de: 'Fotografieren wir die Kuchentheke für den Schulblog.' },
+    { id: 'g8-026', cat: 'Projektarbeit Schule', ru: 'Наша команда готовит видеорепортаж о российской музыке.', de: 'Unser Team bereitet einen Videobericht über russische Musik vor.' },
+    { id: 'g8-027', cat: 'Projektarbeit Schule', ru: 'Давай разделим обязанности: ты монтируешь видео, а я озвучиваю текст.', de: 'Lass uns die Aufgaben teilen: Du schneidest das Video, und ich spreche den Text ein.' },
+    { id: 'g8-028', cat: 'Projektarbeit Schule', ru: 'Срок сдачи проекта – следующая среда, нужно закончить за выходные.', de: 'Abgabe des Projekts ist nächsten Mittwoch, wir müssen es am Wochenende fertigstellen.' },
+    { id: 'g8-029', cat: 'Projektarbeit Schule', ru: 'Учитель просил добавить цитаты из интервью с музыкантом.', de: 'Der Lehrer bat darum, Zitate aus dem Interview mit dem Musiker einzubauen.' },
+    { id: 'g8-030', cat: 'Projektarbeit Schule', ru: 'Перед показом проверим звук на колонках, чтобы не было помех.', de: 'Vor der Präsentation testen wir den Ton auf den Lautsprechern, damit es keine Störungen gibt.' }
+  ],
+  grade9: [
+    { id: 'g9-001', cat: 'Klimaprojekt', ru: 'Мы измеряем качество воздуха возле школы и записываем результаты в таблицу.', de: 'Wir messen die Luftqualität nahe der Schule und tragen die Ergebnisse in eine Tabelle ein.' },
+    { id: 'g9-002', cat: 'Klimaprojekt', ru: 'Не забудь взять перчатки, мы будем сажать молодые деревья во дворе.', de: 'Vergiss die Handschuhe nicht, wir pflanzen junge Bäume im Hof.' },
+    { id: 'g9-003', cat: 'Klimaprojekt', ru: 'На собрании мы обсудим, как сократить использование пластика в столовой.', de: 'In der Besprechung diskutieren wir, wie wir den Plastikverbrauch in der Mensa senken.' },
+    { id: 'g9-004', cat: 'Klimaprojekt', ru: 'Подготовь короткую речь о том, почему сортировка мусора важна.', de: 'Bereite eine kurze Rede darüber vor, warum Mülltrennung wichtig ist.' },
+    { id: 'g9-005', cat: 'Klimaprojekt', ru: 'После уроков мы развесим плакаты с советами по экономии энергии.', de: 'Nach dem Unterricht hängen wir Plakate mit Energiespartipps auf.' },
+    { id: 'g9-006', cat: 'Medienlabor', ru: 'Сегодня мы записываем радиопередачу о школьных новостях.', de: 'Heute nehmen wir eine Radiosendung über Schulnachrichten auf.' },
+    { id: 'g9-007', cat: 'Medienlabor', ru: 'Проверь уровень микрофона, чтобы звук был чистым.', de: 'Überprüfe den Mikrofonpegel, damit der Ton klar ist.' },
+    { id: 'g9-008', cat: 'Medienlabor', ru: 'Для монтажа интервью используй плавные переходы и титры.', de: 'Verwende für den Schnitt des Interviews weiche Übergänge und Untertitel.' },
+    { id: 'g9-009', cat: 'Medienlabor', ru: 'Опубликуем подкаст в полдень, чтобы подписчики успели послушать его по пути домой.', de: 'Wir veröffentlichen den Podcast mittags, damit die Abonnenten ihn auf dem Heimweg hören können.' },
+    { id: 'g9-010', cat: 'Medienlabor', ru: 'Напиши краткое описание выпуска и добавь ссылку на опрос.', de: 'Schreibe eine kurze Episodenbeschreibung und füge den Link zur Umfrage hinzu.' },
+    { id: 'g9-011', cat: 'Freiwilligenarbeit', ru: 'Завтра мы помогаем в приюте, нужно разобрать коробки с одеждой.', de: 'Morgen helfen wir im Obdachlosenheim, wir müssen Kleiderkartons sortieren.' },
+    { id: 'g9-012', cat: 'Freiwilligenarbeit', ru: 'Составим список задач, чтобы распределить работу между волонтёрами.', de: 'Wir erstellen eine Aufgabenliste, um die Arbeit unter den Freiwilligen aufzuteilen.' },
+    { id: 'g9-013', cat: 'Freiwilligenarbeit', ru: 'Поговори с координатором, если нужна дополнительная помощь.', de: 'Sprich mit dem Koordinator, wenn zusätzliche Hilfe nötig ist.' },
+    { id: 'g9-014', cat: 'Freiwilligenarbeit', ru: 'После мероприятия поблагодарим гостей и раздадим информационные буклеты.', de: 'Nach der Veranstaltung danken wir den Gästen und verteilen Infobroschüren.' },
+    { id: 'g9-015', cat: 'Freiwilligenarbeit', ru: 'Не забудь заполнить отчёт о волонтёрских часах для школы.', de: 'Vergiss nicht, den Bericht über die freiwilligen Stunden für die Schule auszufüllen.' },
+    { id: 'g9-016', cat: 'Technologie-Workshop', ru: 'Мы программируем робота, чтобы он смог проехать лабиринт.', de: 'Wir programmieren einen Roboter, damit er das Labyrinth durchfährt.' },
+    { id: 'g9-017', cat: 'Technologie-Workshop', ru: 'Настрой датчик расстояния, иначе он столкнётся со стеной.', de: 'Stell den Abstandssensor ein, sonst stößt er gegen die Wand.' },
+    { id: 'g9-018', cat: 'Technologie-Workshop', ru: 'После теста обсудим, какие алгоритмы сработали лучше.', de: 'Nach dem Test besprechen wir, welche Algorithmen besser funktionierten.' },
+    { id: 'g9-019', cat: 'Technologie-Workshop', ru: 'Подготовь презентацию о том, как использовать 3D-принтер в школьных проектах.', de: 'Bereite eine Präsentation vor, wie man den 3D-Drucker in Schulprojekten nutzt.' },
+    { id: 'g9-020', cat: 'Technologie-Workshop', ru: 'Сделаем короткое видео, чтобы показать наш эксперимент на ярмарке науки.', de: 'Wir drehen ein kurzes Video, um unser Experiment auf der Wissenschaftsmesse zu zeigen.' },
+    { id: 'g9-021', cat: 'Berufsberatung', ru: 'Консультант попросил нас заполнить анкету о наших интересах.', de: 'Der Berater bat uns, einen Fragebogen über unsere Interessen auszufüllen.' },
+    { id: 'g9-022', cat: 'Berufsberatung', ru: 'Мы изучим разные профили университетов и сравним программы.', de: 'Wir schauen uns verschiedene Studienprofile an und vergleichen die Programme.' },
+    { id: 'g9-023', cat: 'Berufsberatung', ru: 'Запиши вопросы для онлайн-встречи с выпускниками.', de: 'Notiere Fragen für das Online-Treffen mit den Absolventen.' },
+    { id: 'g9-024', cat: 'Berufsberatung', ru: 'Проверь резюме на ошибки, прежде чем отправлять его наставнику.', de: 'Überprüfe den Lebenslauf auf Fehler, bevor du ihn an den Mentor sendest.' },
+    { id: 'g9-025', cat: 'Berufsberatung', ru: 'После мастер-класса мы обсудим, какие навыки нужно развивать дальше.', de: 'Nach dem Workshop besprechen wir, welche Fähigkeiten wir weiterentwickeln sollten.' },
+    { id: 'g9-026', cat: 'Internationale Begegnung', ru: 'Сегодня мы готовим презентацию о своём городе для гостей из Польши.', de: 'Heute bereiten wir eine Präsentation über unsere Stadt für Gäste aus Polen vor.' },
+    { id: 'g9-027', cat: 'Internationale Begegnung', ru: 'Давай выучим несколько приветствий на их языке, чтобы сделать сюрприз.', de: 'Lass uns einige Grüße in ihrer Sprache lernen, um sie zu überraschen.' },
+    { id: 'g9-028', cat: 'Internationale Begegnung', ru: 'Во время культурного вечера мы покажем народный танец.', de: 'Während des Kulturabends zeigen wir einen Volkstanz.' },
+    { id: 'g9-029', cat: 'Internationale Begegnung', ru: 'Запланируй совместную игру, чтобы команды быстро познакомились.', de: 'Plane ein gemeinsames Spiel, damit die Teams sich schnell kennenlernen.' },
+    { id: 'g9-030', cat: 'Internationale Begegnung', ru: 'После встречи обменяемся контактами и создадим общий фотоколлаж.', de: 'Nach dem Treffen tauschen wir Kontakte aus und erstellen eine gemeinsame Fotocollage.' }
+  ],
+  grade10: [
+    { id: 'g10-001', cat: 'Gesellschaftliche Debatte', ru: 'Мы обсуждаем, как молодёжь может влиять на решения в своём городе.', de: 'Wir diskutieren, wie Jugendliche Entscheidungen in ihrer Stadt beeinflussen können.' },
+    { id: 'g10-002', cat: 'Gesellschaftliche Debatte', ru: 'Подготовь аргументы за и против добровольного социального года.', de: 'Bereite Argumente für und gegen ein freiwilliges soziales Jahr vor.' },
+    { id: 'g10-003', cat: 'Gesellschaftliche Debatte', ru: 'Во время дебатов важно уважительно реагировать на критику.', de: 'Während der Debatte ist es wichtig, respektvoll auf Kritik zu reagieren.' },
+    { id: 'g10-004', cat: 'Gesellschaftliche Debatte', ru: 'Модератор попросит каждого спикера уложиться в три минуты.', de: 'Der Moderator bittet jeden Sprecher, sich auf drei Minuten zu beschränken.' },
+    { id: 'g10-005', cat: 'Gesellschaftliche Debatte', ru: 'После обсуждения мы составим резолюцию с общими предложениями.', de: 'Nach der Diskussion verfassen wir eine Resolution mit gemeinsamen Vorschlägen.' },
+    { id: 'g10-006', cat: 'Politisches Planspiel', ru: 'Наша фракция готовит поправку к законопроекту об экологии.', de: 'Unsere Fraktion bereitet einen Änderungsantrag zum Umweltgesetz vor.' },
+    { id: 'g10-007', cat: 'Politisches Planspiel', ru: 'Договоримся о коалиции, чтобы набрать большинство голосов.', de: 'Wir vereinbaren eine Koalition, um die Mehrheit der Stimmen zu erreichen.' },
+    { id: 'g10-008', cat: 'Politisches Planspiel', ru: 'Перед голосованием мы представим краткое обоснование наших идей.', de: 'Vor der Abstimmung präsentieren wir eine kurze Begründung unserer Ideen.' },
+    { id: 'g10-009', cat: 'Politisches Planspiel', ru: 'Секретарь заседания записывает все решения в протокол.', de: 'Der Sitzungssekretär protokolliert alle Beschlüsse.' },
+    { id: 'g10-010', cat: 'Politisches Planspiel', ru: 'После игры сравним наши выводы с реальными примерами из новостей.', de: 'Nach dem Planspiel vergleichen wir unsere Ergebnisse mit realen Beispielen aus den Nachrichten.' },
+    { id: 'g10-011', cat: 'Wirtschaft & Innovation', ru: 'Мы анализируем бизнес-модель стартапа, который разрабатывает умные дома.', de: 'Wir analysieren das Geschäftsmodell eines Start-ups, das Smart Homes entwickelt.' },
+    { id: 'g10-012', cat: 'Wirtschaft & Innovation', ru: 'Рассчитай бюджет проекта и учти расходы на маркетинг.', de: 'Berechne das Projektbudget und berücksichtige die Marketingkosten.' },
+    { id: 'g10-013', cat: 'Wirtschaft & Innovation', ru: 'Инвестор хочет услышать, какую социальную пользу принесёт наше решение.', de: 'Der Investor möchte hören, welchen gesellschaftlichen Nutzen unsere Lösung bringt.' },
+    { id: 'g10-014', cat: 'Wirtschaft & Innovation', ru: 'Подготовь слайды с графиками роста и потенциальными рисками.', de: 'Bereite Folien mit Wachstumskurven und potenziellen Risiken vor.' },
+    { id: 'g10-015', cat: 'Wirtschaft & Innovation', ru: 'После презентации ответь на вопросы о конкурентах на рынке.', de: 'Beantworte nach der Präsentation Fragen zu den Wettbewerbern auf dem Markt.' },
+    { id: 'g10-016', cat: 'Kulturelles Symposium', ru: 'Мы организуем круглые столы о влиянии литературы на общество.', de: 'Wir organisieren Roundtables über den Einfluss der Literatur auf die Gesellschaft.' },
+    { id: 'g10-017', cat: 'Kulturelles Symposium', ru: 'Приглашённый историк расскажет о развитии русской архитектуры.', de: 'Der eingeladene Historiker berichtet über die Entwicklung der russischen Architektur.' },
+    { id: 'g10-018', cat: 'Kulturelles Symposium', ru: 'Для выставки нужно подготовить аннотации к каждому произведению искусства.', de: 'Für die Ausstellung müssen wir Anmerkungen zu jedem Kunstwerk vorbereiten.' },
+    { id: 'g10-019', cat: 'Kulturelles Symposium', ru: 'Во время перерыва прозвучит живая музыка студентов консерватории.', de: 'In der Pause spielt Live-Musik von Konservatoriumsstudenten.' },
+    { id: 'g10-020', cat: 'Kulturelles Symposium', ru: 'После завершения симпозиума участники обменяются издательскими планами.', de: 'Nach dem Symposium tauschen die Teilnehmer Verlagspläne aus.' },
+    { id: 'g10-021', cat: 'Medienkritik', ru: 'Мы анализируем, как новостные порталы формулируют заголовки.', de: 'Wir analysieren, wie Nachrichtenportale ihre Überschriften formulieren.' },
+    { id: 'g10-022', cat: 'Medienkritik', ru: 'Сравни факты в статье с официальными данными и отметь расхождения.', de: 'Vergleiche die Fakten des Artikels mit offiziellen Daten und markiere Abweichungen.' },
+    { id: 'g10-023', cat: 'Medienkritik', ru: 'Подготовь комментарий о роли блогеров в общественных дискуссиях.', de: 'Bereite einen Kommentar zur Rolle von Bloggern in öffentlichen Debatten vor.' },
+    { id: 'g10-024', cat: 'Medienkritik', ru: 'На семинаре мы обсудим, как распознавать манипулятивные фотографии.', de: 'Im Seminar besprechen wir, wie man manipulative Fotos erkennt.' },
+    { id: 'g10-025', cat: 'Medienkritik', ru: 'В конце занятия каждый представит короткую рецензию на выбранный материал.', de: 'Zum Schluss präsentiert jeder eine kurze Rezension zum gewählten Material.' },
+    { id: 'g10-026', cat: 'Zukunftsvisionen', ru: 'Представь город будущего, где общественный транспорт работает на водороде.', de: 'Stell dir eine Stadt der Zukunft vor, in der der öffentliche Verkehr mit Wasserstoff fährt.' },
+    { id: 'g10-027', cat: 'Zukunftsvisionen', ru: 'Опиши, как технологии помогут решить проблему доступного жилья.', de: 'Beschreibe, wie Technologie helfen wird, das Problem des bezahlbaren Wohnraums zu lösen.' },
+    { id: 'g10-028', cat: 'Zukunftsvisionen', ru: 'Нарисуй карту районов, где природа и архитектура соединены гармонично.', de: 'Zeichne eine Karte von Vierteln, in denen Natur und Architektur harmonisch verbunden sind.' },
+    { id: 'g10-029', cat: 'Zukunftsvisionen', ru: 'После мозгового штурма выберем три идеи и разработаем прототипы.', de: 'Nach dem Brainstorming wählen wir drei Ideen aus und entwickeln Prototypen.' },
+    { id: 'g10-030', cat: 'Zukunftsvisionen', ru: 'Подготовь вдохновляющую речь о том, почему важно мечтать смело.', de: 'Bereite eine inspirierende Rede darüber vor, warum es wichtig ist, mutig zu träumen.' }
+  ]
+const ALPHABET = [
+  { ru: 'А а', name: 'A' },
+  { ru: 'Б б', name: 'Be' },
+  { ru: 'В в', name: 'We' },
+  { ru: 'Г г', name: 'Ge' },
+  { ru: 'Д д', name: 'De' },
+  { ru: 'Е е', name: 'Je' },
+  { ru: 'Ё ё', name: 'Jo' },
+  { ru: 'Ж ж', name: 'Sche' },
+  { ru: 'З з', name: 'Se' },
+  { ru: 'И и', name: 'I' },
+  { ru: 'Й й', name: 'Kurzes I' },
+  { ru: 'К к', name: 'Ka' },
+  { ru: 'Л л', name: 'El' },
+  { ru: 'М м', name: 'Em' },
+  { ru: 'Н н', name: 'En' },
+  { ru: 'О о', name: 'O' },
+  { ru: 'П п', name: 'Pe' },
+  { ru: 'Р р', name: 'Er' },
+  { ru: 'С с', name: 'Es' },
+  { ru: 'Т т', name: 'Te' },
+  { ru: 'У у', name: 'U' },
+  { ru: 'Ф ф', name: 'Ef' },
+  { ru: 'Х х', name: 'Cha' },
+  { ru: 'Ц ц', name: 'Zé' },
+  { ru: 'Ч ч', name: 'Tsche' },
+  { ru: 'Ш ш', name: 'Sch' },
+  { ru: 'Щ щ', name: 'Schtsch' },
+  { ru: 'Ъ ъ', name: 'Hartes Zeichen' },
+  { ru: 'Ы ы', name: 'Y' },
+  { ru: 'Ь ь', name: 'Weiches Zeichen' },
+  { ru: 'Э э', name: 'E' },
+  { ru: 'Ю ю', name: 'Ju' },
+  { ru: 'Я я', name: 'Ja' }
+];
+
+const ACHIEVEMENTS = [
+  { id: 'first-word', title: 'Erstes Wort', desc: 'Du hast dein erstes russisches Wort gemeistert!', test: (s) => s.learned.size >= 1 },
+  { id: 'dozen', title: 'Dutzend Worte', desc: 'Zwölf Vokabeln wandern in dein Repertoire.', test: (s) => s.learned.size >= 12 },
+  { id: 'consistent', title: 'Konstanz', desc: 'Halte deinen Streak über mehrere Tage.', test: (s) => s.streak >= 3 },
+  { id: 'accuracy', title: 'Treffsicher', desc: 'Über 80 % deiner Antworten sitzen.', test: (s) => s.answersTotal >= 10 && (s.answersCorrect / s.answersTotal) >= 0.8 }
+];
+
+const $ = (sel, el = document) => el.querySelector(sel);
+const $$ = (sel, el = document) => [...el.querySelectorAll(sel)];
+
 const state = {
-  dark: false,
+  theme: 'midnight',
+  grade: 'grade7',
+  showLanding: true,
+  useCustomData: false,
+  customDataset: [],
   sfx: true,
   dyslexic: false,
   voice: null,
@@ -14,124 +651,636 @@ const state = {
   mode: 'mc',
   score: 0,
   total: 0,
-  accuracy: 0,
+  answersTotal: 0,
+  answersCorrect: 0,
   streak: 0,
   learned: new Set(),
-  srs: {},          // id: {box: 1..5, due: timestamp}
+  srs: {},
   favs: new Set(),
   hard: new Set(),
   achievements: {},
   daily: { date: null, done: false },
+  musicEl: null
 };
 
-const STORAGE_KEY = 'ru-vocab-deluxe-v1';
-const load = () => {
+const STORAGE_KEY = 'ru-vocab-deluxe-v2';
+
+function load() {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return;
     const data = JSON.parse(raw);
-    Object.assign(state, data, {
-      learned: new Set(data.learned || []),
-      favs: new Set(data.favs || []),
-      hard: new Set(data.hard || []),
-    });
-  } catch {}
-};
-const save = () => {
-  const toSave = {...state,
+    state.theme = data.theme || state.theme;
+    state.grade = data.grade || state.grade;
+    if (!GRADE_INFO[state.grade]) {
+      const legacy = { beginner: 'grade7', intermediate: 'grade8', advanced: 'grade10' };
+      state.grade = legacy[data.grade] || 'grade7';
+    }
+    state.showLanding = data.showLanding ?? state.showLanding;
+    state.useCustomData = data.useCustomData ?? state.useCustomData;
+    state.customDataset = data.customDataset || [];
+    state.sfx = data.sfx ?? state.sfx;
+    state.dyslexic = data.dyslexic ?? state.dyslexic;
+    state.voice = data.voice || null;
+    state.answersTotal = data.answersTotal || 0;
+    state.answersCorrect = data.answersCorrect || 0;
+    state.streak = data.streak || 0;
+    state.learned = new Set(data.learned || []);
+    state.srs = data.srs || {};
+    state.favs = new Set(data.favs || []);
+    state.hard = new Set(data.hard || []);
+    state.achievements = data.achievements || {};
+    state.daily = data.daily || state.daily;
+  } catch (err) {
+    console.warn('Konnte Speicher nicht laden:', err);
+  }
+}
+
+function save() {
+  const toSave = {
+    theme: state.theme,
+    grade: state.grade,
+    showLanding: state.showLanding,
+    useCustomData: state.useCustomData,
+    customDataset: state.customDataset,
+    sfx: state.sfx,
+    dyslexic: state.dyslexic,
+    voice: state.voice,
+    answersTotal: state.answersTotal,
+    answersCorrect: state.answersCorrect,
+    streak: state.streak,
     learned: [...state.learned],
+    srs: state.srs,
     favs: [...state.favs],
     hard: [...state.hard],
+    achievements: state.achievements,
+    daily: state.daily
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(toSave));
-};
+}
 
-function randInt(n){ return Math.floor(Math.random()*n); }
-function shuffle(a){ for(let i=a.length-1;i>0;i--){ const j=randInt(i+1); [a[i],a[j]]=[a[j],a[i]];} return a; }
-
-async function init(){
+function init() {
   load();
   bindUI();
+  buildThemeSelectors();
+  buildGradeSelectors();
   themeApply();
-  await loadData();
+  setThemeMusic(state.theme);
+  refreshDataset();
   buildCategories();
   buildAlphabetGrid();
   updateStats();
+  unlockAchievements();
+  toggleLanding(state.showLanding);
+  updateAudioIcon();
   registerSW();
   drawChartDummy();
   setupInstall();
   scanVoices();
+  document.addEventListener('visibilitychange', () => syncThemeMusic(), { passive: true });
 }
 
-async function loadData(){
-  const base = await fetch('data/vocab.ru.json').then(r=>r.json());
-  state.dataset = base;
-  state.categories = [...new Set(base.map(x=>x.cat))];
-  // init SRS map
-  for (const item of base){
-    if (!state.srs[item.id]) state.srs[item.id] = {box:1, due: Date.now()};
+function bindUI() {
+  $$('.tab').forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const id = tab.dataset.tab;
+      if (!id) return;
+      $$('.tab').forEach((t) => {
+        t.classList.toggle('active', t === tab);
+        t.setAttribute('aria-selected', String(t === tab));
+      });
+      $$('.panel').forEach((panel) => panel.classList.remove('visible'));
+      const target = $('#' + id);
+      if (target) target.classList.add('visible');
+    });
+  });
+
+  const startBtn = $('#btn-start');
+  if (startBtn) {
+    startBtn.onclick = () => {
+      state.mode = $('#mode-select').value;
+      if (!state.categories.length) {
+        $('#feedback').textContent = 'Bitte zuerst eine Wortliste wählen.';
+        return;
+      }
+      selectSet();
+      nextCard();
+      toggleLanding(false);
+      state.showLanding = false;
+      syncThemeMusic();
+      save();
+    };
+  }
+
+  const nextBtn = $('#btn-next');
+  if (nextBtn) nextBtn.onclick = () => nextCard();
+
+  const revealBtn = $('#btn-reveal');
+  if (revealBtn) {
+    revealBtn.onclick = () => {
+      const prompt = $('#prompt');
+      if (!prompt) return;
+      const answer = prompt.dataset.answer;
+      $('#feedback').textContent = answer ? `Lösung: ${answer}` : 'Keine Lösung gefunden.';
+    };
+  }
+
+  const sayBtn = $('#btn-say');
+  if (sayBtn) {
+    sayBtn.onclick = () => {
+      const prompt = $('#prompt');
+      const text = prompt?.dataset.ru || prompt?.textContent || '';
+      speak(text, 'ru-RU');
+    };
+  }
+
+  const practiceSayBtn = $('#btn-practice-say');
+  if (practiceSayBtn) {
+    practiceSayBtn.onclick = () => {
+      const prompt = $('#practice-prompt');
+      const text = prompt?.dataset.ru || prompt?.textContent || '';
+      speak(text, 'ru-RU');
+    };
+  }
+
+  const answerInput = $('#answer');
+  if (answerInput) {
+    answerInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        const current = state.currentSet[state.currentIndex];
+        if (!current) return;
+        checkAnswer($('#answer').value, $('#prompt').dataset.answer, current);
+      }
+    });
+  }
+
+  const practiceActions = $('#practice .actions');
+  if (practiceActions) {
+    practiceActions.addEventListener('click', (e) => {
+      const btn = e.target.closest('button[data-grade]');
+      if (!btn) return;
+      gradePractice(Number(btn.dataset.grade));
+    });
+  }
+
+  const dueBtn = $('#btn-due');
+  if (dueBtn) dueBtn.onclick = () => startDuePractice();
+
+  const alphaQuiz = $('#btn-alpha-quiz');
+  if (alphaQuiz) alphaQuiz.onclick = () => startAlphabetQuiz();
+
+  const alphaAudio = $('#btn-alpha-audio');
+  if (alphaAudio) {
+    alphaAudio.onclick = () => {
+      const sel = $('.alpha-item.selected');
+      if (sel) speak(sel.dataset.ru, 'ru-RU');
+    };
+  }
+
+  const themeBtn = $('#btn-theme');
+  if (themeBtn) themeBtn.onclick = () => cycleTheme();
+
+  const audioBtn = $('#btn-audio');
+  if (audioBtn) {
+    audioBtn.onclick = () => {
+      state.sfx = !state.sfx;
+      $('#toggle-sfx').checked = state.sfx;
+      updateAudioIcon();
+      save();
+    };
+  }
+
+  const landingEnter = $('#landing-enter');
+  if (landingEnter) {
+    landingEnter.onclick = () => {
+      state.showLanding = false;
+      toggleLanding(false);
+      syncThemeMusic();
+      save();
+    };
+  }
+
+  const toggleSfx = $('#toggle-sfx');
+  if (toggleSfx) {
+    toggleSfx.checked = state.sfx;
+    toggleSfx.onchange = (e) => {
+      state.sfx = e.target.checked;
+      updateAudioIcon();
+      save();
+    };
+  }
+
+  const toggleDys = $('#toggle-dyslexic');
+  if (toggleDys) {
+    toggleDys.checked = state.dyslexic;
+    toggleDys.onchange = (e) => {
+      state.dyslexic = e.target.checked;
+      document.body.classList.toggle('dyslexic', state.dyslexic);
+      save();
+    };
+    document.body.classList.toggle('dyslexic', state.dyslexic);
+  }
+
+  const customToggle = $('#toggle-custom-data');
+  if (customToggle) {
+    customToggle.checked = state.useCustomData;
+    customToggle.onchange = (e) => {
+      state.useCustomData = e.target.checked;
+      updateCustomDataTools();
+      refreshDataset();
+      buildCategories();
+      save();
+    };
+  }
+  updateCustomDataTools();
+
+  const importBtn = $('#btn-import');
+  const exportBtn = $('#btn-export');
+  const fileInput = $('#file-input');
+  if (importBtn && fileInput) {
+    importBtn.onclick = () => fileInput.click();
+    fileInput.onchange = async (e) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const data = JSON.parse(text);
+        if (!Array.isArray(data)) throw new Error('JSON muss ein Array sein.');
+        state.customDataset = normalizeDataset(data, 'custom');
+        state.useCustomData = true;
+        $('#toggle-custom-data').checked = true;
+        updateCustomDataTools();
+        refreshDataset();
+        buildCategories();
+        save();
+        alert('Import erfolgreich – deine Liste ist aktiv.');
+      } catch (err) {
+        console.error(err);
+        alert('Fehler beim Import: ' + err.message);
+      } finally {
+        fileInput.value = '';
+      }
+    };
+  }
+  if (exportBtn) {
+    exportBtn.onclick = () => {
+      const blob = new Blob([JSON.stringify(state.dataset, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'vocab-export.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    };
+  }
+
+  const voiceScan = $('#btn-voice-scan');
+  if (voiceScan) voiceScan.onclick = () => scanVoices();
+
+  const voiceSelect = $('#voice-select');
+  if (voiceSelect) {
+    voiceSelect.onchange = (e) => {
+      const idx = Number(e.target.value);
+      state.voice = state.voices[idx] || null;
+      save();
+    };
+  }
+
+  const resetBtn = $('#btn-reset');
+  if (resetBtn) {
+    resetBtn.onclick = () => {
+      if (confirm('Wirklich alle Daten löschen?')) {
+        localStorage.removeItem(STORAGE_KEY);
+        location.reload();
+      }
+    };
   }
 }
 
-function buildCategories(){
-  const sel = $('#category-select');
-  sel.innerHTML = '';
-  for (const c of state.categories){
+function updateCustomDataTools() {
+  const tools = $('#custom-data-tools');
+  if (!tools) return;
+  tools.classList.toggle('hidden', !state.useCustomData);
+}
+
+function updateAudioIcon() {
+  const useEl = $('#icon-audio-use');
+  if (!useEl) return;
+  useEl.setAttribute('href', state.sfx ? '#icon-audio' : '#icon-audio-off');
+  const audioBtn = $('#btn-audio');
+  if (audioBtn) {
+    audioBtn.setAttribute('aria-label', state.sfx ? 'Sound und Musik stummschalten' : 'Sound und Musik einschalten');
+  }
+  syncThemeMusic();
+}
+
+function ensureMusicEl() {
+  if (state.musicEl && document.body.contains(state.musicEl)) return state.musicEl;
+  const el = $('#theme-music');
+  if (!el) return null;
+  el.volume = 0.35;
+  el.loop = true;
+  el.setAttribute('aria-hidden', 'true');
+  state.musicEl = el;
+  return state.musicEl;
+}
+
+function setThemeMusic(themeKey) {
+  const audio = ensureMusicEl();
+  const theme = THEMES[themeKey];
+  if (!audio || !theme || !theme.music) {
+    if (audio) {
+      audio.pause();
+      audio.removeAttribute('data-theme');
+      audio.removeAttribute('src');
+    }
+    return;
+  }
+  if (audio.dataset.theme === themeKey && audio.src) {
+    syncThemeMusic();
+    return;
+  }
+  audio.dataset.theme = themeKey;
+  audio.src = theme.music;
+  audio.load();
+  if (state.sfx && !document.hidden) {
+    const playPromise = audio.play();
+    if (playPromise?.catch) playPromise.catch(() => {});
+  }
+}
+
+function syncThemeMusic() {
+  const audio = ensureMusicEl();
+  if (!audio) return;
+  const theme = THEMES[state.theme];
+  if (!theme || !theme.music || !state.sfx || document.hidden) {
+    audio.pause();
+    return;
+  }
+  if (audio.dataset.theme !== state.theme) {
+    setThemeMusic(state.theme);
+    return;
+  }
+  const playPromise = audio.play();
+  if (playPromise?.catch) playPromise.catch(() => {});
+}
+
+function buildThemeSelectors() {
+  const containers = [$('#landing-theme-grid'), $('#settings-theme-grid')].filter(Boolean);
+  containers.forEach((container) => {
+    container.innerHTML = '';
+    Object.entries(THEMES).forEach(([key, theme]) => {
+      const card = document.createElement('button');
+      card.type = 'button';
+      card.className = 'theme-card';
+      card.dataset.themeId = key;
+      card.style.setProperty('--theme-bg', theme.preview);
+      card.style.setProperty('--theme-overlay', theme.overlay);
+      card.style.setProperty('--theme-image', theme.image || theme.vars['--bg-art'] || 'none');
+      const icon = theme.icon
+        ? `<span class="theme-card__icon" aria-hidden="true"><svg class="icon"><use href="#${theme.icon}"></use></svg></span>`
+        : '';
+      card.innerHTML = `${icon}<div class="theme-card__body"><strong>${theme.label}</strong><span>${theme.description}</span></div>`;
+      card.setAttribute('aria-pressed', 'false');
+      card.onclick = () => {
+        setTheme(key);
+      };
+      container.appendChild(card);
+    });
+  });
+  highlightActiveTheme();
+}
+
+function highlightActiveTheme() {
+  $$('.theme-card').forEach((card) => {
+    const isActive = card.dataset.themeId === state.theme;
+    card.classList.toggle('active', isActive);
+    card.setAttribute('aria-pressed', String(isActive));
+  });
+}
+
+function setTheme(themeKey) {
+  if (!THEMES[themeKey]) return;
+  state.theme = themeKey;
+  themeApply();
+  setThemeMusic(themeKey);
+  syncThemeMusic();
+  highlightActiveTheme();
+  save();
+}
+
+function cycleTheme() {
+  const keys = Object.keys(THEMES);
+  const idx = keys.indexOf(state.theme);
+  const next = keys[(idx + 1) % keys.length];
+  setTheme(next);
+}
+
+function themeApply() {
+  const theme = THEMES[state.theme] || THEMES.midnight;
+  Object.entries(theme.vars).forEach(([key, value]) => {
+    document.documentElement.style.setProperty(key, value);
+  });
+  document.body.dataset.theme = state.theme;
+  document.body.classList.toggle('dyslexic', state.dyslexic);
+}
+
+function buildGradeSelectors() {
+  const containers = [$('#landing-grade-grid'), $('#settings-grade-grid')].filter(Boolean);
+  containers.forEach((container) => {
+    container.innerHTML = '';
+    Object.entries(GRADE_INFO).forEach(([key, info]) => {
+      const card = document.createElement('button');
+      card.type = 'button';
+      card.className = 'grade-card';
+      card.dataset.grade = key;
+      const ribbon = info.ribbon || 'radial-gradient(circle at 30% 40%, rgba(255,255,255,0.28), transparent 65%)';
+      card.style.setProperty('--grade-ribbon', ribbon);
+      const icon = info.icon
+        ? `<span class="grade-card__icon" aria-hidden="true"><svg class="icon"><use href="#${info.icon}"></use></svg></span>`
+        : '';
+      card.innerHTML = `${icon}<div class="grade-card__body"><strong>${info.label}</strong><span>${info.description}</span></div>`;
+      card.setAttribute('aria-pressed', 'false');
+      card.onclick = () => setGrade(key);
+      container.appendChild(card);
+    });
+  });
+  highlightGrade();
+}
+
+function highlightGrade() {
+  $$('.grade-card').forEach((card) => {
+    card.classList.toggle('active', card.dataset.grade === state.grade);
+    card.setAttribute('aria-pressed', String(card.dataset.grade === state.grade));
+  });
+}
+
+function setGrade(grade) {
+  if (!GRADE_INFO[grade]) return;
+  state.grade = grade;
+  highlightGrade();
+  if (!state.useCustomData) {
+    refreshDataset();
+    buildCategories();
+  }
+  save();
+}
+
+function toggleLanding(show) {
+  const landing = $('#landing');
+  if (!landing) return;
+  landing.classList.toggle('visible', show);
+  landing.setAttribute('aria-hidden', String(!show));
+  document.body.classList.toggle('no-scroll', show);
+}
+
+function normalizeDataset(list, prefix) {
+  return list.map((item, idx) => {
+    const art = CATEGORY_ART[item.cat] || {};
+    return {
+      id: item.id || `${prefix}-${idx}`,
+      cat: item.cat || 'Allgemein',
+      ru: item.ru,
+      de: item.de,
+      image: item.image || art.image || '',
+      accent: item.accent || art.accent || '#7f8cff'
+    };
+  }).filter((item) => item.ru && item.de);
+}
+
+function refreshDataset() {
+  const source = state.useCustomData && state.customDataset.length
+    ? state.customDataset
+    : BUILT_IN_WORDS[state.grade] || [];
+  state.dataset = normalizeDataset(source, state.useCustomData ? 'custom' : state.grade);
+  state.categories = [...new Set(state.dataset.map((item) => item.cat))];
+  ensureSrsIntegrity();
+}
+
+function ensureSrsIntegrity() {
+  const valid = new Set(state.dataset.map((item) => item.id));
+  Object.keys(state.srs).forEach((id) => {
+    if (!valid.has(id)) delete state.srs[id];
+  });
+  state.dataset.forEach((item) => {
+    if (!state.srs[item.id]) state.srs[item.id] = { box: 1, due: Date.now() };
+  });
+}
+
+function buildCategories() {
+  const select = $('#category-select');
+  if (!select) return;
+  select.innerHTML = '';
+  if (!state.categories.length) {
     const opt = document.createElement('option');
-    opt.value = c; opt.textContent = c;
-    sel.appendChild(opt);
+    opt.textContent = 'Keine Vokabeln verfügbar';
+    opt.value = '';
+    select.appendChild(opt);
+    return;
+  }
+  state.categories.forEach((cat) => {
+    const opt = document.createElement('option');
+    opt.value = cat;
+    opt.textContent = cat;
+    select.appendChild(opt);
+  });
+}
+
+function updateScene(prefix, item) {
+  const visual = document.getElementById(`${prefix}-visual`);
+  const category = document.getElementById(`${prefix}-category`);
+  const accent = item?.accent || CATEGORY_ART[item?.cat]?.accent || '#7f8cff';
+  if (visual) {
+    if (item?.image) {
+      visual.style.setProperty('--scene-image', `url("${item.image}")`);
+    } else {
+      visual.style.setProperty('--scene-image', 'none');
+    }
+    visual.style.setProperty('--scene-accent', accent);
+  }
+  if (category) {
+    if (item?.cat) {
+      category.hidden = false;
+      category.textContent = item.cat;
+      category.style.setProperty('--tag-accent', accent);
+    } else {
+      category.hidden = true;
+      category.textContent = '';
+      category.style.removeProperty('--tag-accent');
+    }
   }
 }
 
-function selectSet(){
-  const cat = $('#category-select').value;
-  const arr = state.dataset.filter(x=>x.cat===cat);
+function selectSet() {
+  const select = $('#category-select');
+  const cat = select?.value || state.categories[0];
+  const arr = state.dataset.filter((item) => item.cat === cat);
   state.currentSet = shuffle(arr.slice());
   state.currentIndex = 0;
-  state.score = 0; state.total = state.currentSet.length;
+  state.score = 0;
+  state.total = state.currentSet.length;
   $('#bar').style.width = '0%';
 }
 
-function nextCard(){
+function nextCard() {
   const item = state.currentSet[state.currentIndex];
-  if (!item) { endSession(); return; }
+  if (!item) {
+    endSession();
+    return;
+  }
   $('#feedback').textContent = '';
   $('#answer').value = '';
   $('#choices').innerHTML = '';
   const mode = state.mode;
-  const promptSide = Math.random() < 0.5 ? 'ru' : 'de';
-  $('#prompt').textContent = promptSide==='ru' ? item.ru : item.de;
-  $('#prompt').dataset.answer = promptSide==='ru' ? item.de : item.ru;
-  if (mode === 'mc'){
-    const pool = shuffle(state.dataset.filter(x=>x.id!==item.id)).slice(0,3).map(x => promptSide==='ru' ? x.de : x.ru);
+  const promptSide = mode === 'audio' ? 'ru' : (Math.random() < 0.5 ? 'ru' : 'de');
+  const promptText = promptSide === 'ru' ? item.ru : item.de;
+  const promptEl = $('#prompt');
+  if (promptEl) {
+    promptEl.textContent = promptText;
+    promptEl.dataset.answer = promptSide === 'ru' ? item.de : item.ru;
+    promptEl.dataset.ru = item.ru;
+  }
+  updateScene('prompt', item);
+
+  if (mode === 'mc') {
+    const pool = shuffle(state.dataset.filter((x) => x.id !== item.id)).slice(0, 3)
+      .map((x) => (promptSide === 'ru' ? x.de : x.ru));
     const correct = $('#prompt').dataset.answer;
     const opts = shuffle([...pool, correct]);
-    for (const txt of opts){
-      const b = document.createElement('button');
-      b.className = 'choice-btn';
-      b.textContent = txt;
-      b.onclick = () => checkAnswer(txt, correct, item);
-      $('#choices').appendChild(b);
-    }
+    opts.forEach((txt) => {
+      const button = document.createElement('button');
+      button.className = 'choice-btn';
+      button.type = 'button';
+      button.textContent = txt;
+      button.onclick = () => checkAnswer(txt, correct, item);
+      $('#choices').appendChild(button);
+    });
     $('#answer').style.display = 'none';
     $('#choices').style.display = 'grid';
   } else {
     $('#answer').style.display = 'block';
     $('#choices').style.display = 'none';
     $('#answer').focus();
+    if (mode === 'audio') {
+      speak(item.ru, 'ru-RU');
+      $('#prompt').textContent = '🔈 Höre zu und tippe die Übersetzung';
+    }
   }
-  $('#progress #bar').style.width = `${Math.round((state.currentIndex)/state.total*100)}%`;
+  const progress = state.total ? Math.round((state.currentIndex) / state.total * 100) : 0;
+  $('#bar').style.width = `${progress}%`;
 }
 
-function checkAnswer(given, correct, item){
-  const ok = given.trim().toLowerCase() === correct.trim().toLowerCase();
+function checkAnswer(given, correct, item) {
+  const normalized = (str) => str.trim().toLowerCase();
+  const ok = normalized(given) === normalized(correct);
   feedback(ok, correct);
   updateStatsAfterAnswer(ok, item);
 }
 
-function feedback(ok, correct){
+function feedback(ok, correct) {
   const el = $('#feedback');
-  if (ok){
+  if (!el) return;
+  if (ok) {
     el.textContent = 'Richtig!';
     confetti();
     ping(true);
@@ -141,47 +1290,51 @@ function feedback(ok, correct){
   }
 }
 
-function updateStatsAfterAnswer(ok, item){
-  state.accuracy = Math.round(((state.accuracy*state.learned.size) + (ok?1:0)) / (state.learned.size+1) * 100);
-  state.learned.add(item.id);
-  if (ok){
+function updateStatsAfterAnswer(ok, item) {
+  state.answersTotal += 1;
+  if (ok) {
+    state.answersCorrect += 1;
     promoteSRS(item.id);
+    state.learned.add(item.id);
     unlockAchievements();
   } else {
     demoteSRS(item.id);
   }
-  state.currentIndex++;
-  $('#bar').style.width = `${Math.round((state.currentIndex)/state.total*100)}%`;
+  state.currentIndex += 1;
+  const progress = state.total ? Math.round((state.currentIndex) / state.total * 100) : 0;
+  $('#bar').style.width = `${progress}%`;
   save();
+  updateStats();
 }
 
-function endSession(){
-  $('#feedback').textContent = 'Session beendet.';
+function endSession() {
+  $('#feedback').textContent = 'Session beendet. Großartig gemacht!';
 }
 
-function promoteSRS(id){
-  const s = state.srs[id] || {box:1, due:Date.now()};
-  s.box = Math.min(5, s.box+1);
-  const days = [0,1,2,4,7,14][s.box];
-  s.due = Date.now() + days*24*3600*1000;
-  state.srs[id] = s;
-}
-function demoteSRS(id){
-  const s = state.srs[id] || {box:1, due:Date.now()};
-  s.box = Math.max(1, s.box-1);
-  s.due = Date.now() + 12*3600*1000;
-  state.srs[id] = s;
+function promoteSRS(id) {
+  const entry = state.srs[id] || { box: 1, due: Date.now() };
+  entry.box = Math.min(5, entry.box + 1);
+  const days = [0, 1, 2, 4, 7, 14][entry.box];
+  entry.due = Date.now() + days * 24 * 3600 * 1000;
+  state.srs[id] = entry;
 }
 
-function srsDueSet(){
+function demoteSRS(id) {
+  const entry = state.srs[id] || { box: 1, due: Date.now() };
+  entry.box = Math.max(1, entry.box - 1);
+  entry.due = Date.now() + 12 * 3600 * 1000;
+  state.srs[id] = entry;
+}
+
+function srsDueSet() {
   const now = Date.now();
-  return state.dataset.filter(x => (state.srs[x.id]?.due ?? 0) <= now);
+  return state.dataset.filter((item) => (state.srs[item.id]?.due ?? 0) <= now);
 }
 
-function startDuePractice(){
+function startDuePractice() {
   const due = srsDueSet();
-  if (!due.length){
-    $('#practice-feedback').textContent = 'Heute nichts fällig. Luxus.';
+  if (!due.length) {
+    $('#practice-feedback').textContent = 'Heute nichts fällig. Genieße deine freie Zeit!';
     return;
   }
   state.currentSet = shuffle(due);
@@ -189,113 +1342,83 @@ function startDuePractice(){
   nextPractice();
 }
 
-function nextPractice(){
+function nextPractice() {
   const item = state.currentSet[state.currentIndex];
-  if (!item){ $('#practice-feedback').textContent = 'Fertig.'; return; }
-  $('#practice-answer').value='';
-  $('#practice-prompt').textContent = Math.random()<0.5 ? item.ru : item.de;
-  $('#practice-prompt').dataset.answer = $('#practice-prompt').textContent===item.ru ? item.de : item.ru;
+  if (!item) {
+    $('#practice-feedback').textContent = 'Fertig. Gut gemacht!';
+    return;
+  }
+  $('#practice-answer').value = '';
+  const showRussian = Math.random() < 0.5;
+  const practicePrompt = $('#practice-prompt');
+  if (practicePrompt) {
+    practicePrompt.textContent = showRussian ? item.ru : item.de;
+    practicePrompt.dataset.answer = showRussian ? item.de : item.ru;
+    practicePrompt.dataset.ru = item.ru;
+  }
+  updateScene('practice', item);
 }
 
-function gradePractice(grade){
+function gradePractice(grade) {
   const item = state.currentSet[state.currentIndex];
+  if (!item) return;
   const given = $('#practice-answer').value.trim().toLowerCase();
   const correct = $('#practice-prompt').dataset.answer.trim().toLowerCase();
   const ok = given === correct || grade >= 5;
-  if (ok) promoteSRS(item.id); else demoteSRS(item.id);
-  $('#practice-feedback').textContent = ok ? 'Gut!' : `Nope. Richtig: ${correct}`;
-  state.currentIndex++;
+  if (ok) {
+    promoteSRS(item.id);
+    state.answersCorrect += 1;
+    state.learned.add(item.id);
+  } else {
+    demoteSRS(item.id);
+  }
+  state.answersTotal += 1;
+  $('#practice-feedback').textContent = ok ? 'Sehr gut!' : `Richtig wäre: ${correct}`;
+  state.currentIndex += 1;
   save();
+  updateStats();
   nextPractice();
 }
 
-/* UI Binds */
-function bindUI(){
-  $$('.tab').forEach(b => b.addEventListener('click', () => {
-    $$('.tab').forEach(x=>x.classList.remove('active'));
-    b.classList.add('active');
-    const id = b.dataset.tab;
-    $$('.panel').forEach(p => p.classList.remove('visible'));
-    $('#'+id).classList.add('visible');
-  }));
-  $('#btn-dark').onclick = () => { state.dark = !state.dark; themeApply(); save(); };
-  $('#toggle-dark').onchange = e => { state.dark = e.target.checked; themeApply(); save(); };
-  $('#toggle-sfx').onchange = e => { state.sfx = e.target.checked; save(); };
-  $('#toggle-dyslexic').onchange = e => { state.dyslexic = e.target.checked; document.body.classList.toggle('dyslexic', state.dyslexic); save(); };
+function updateStats() {
+  $('#stat-learned').textContent = state.learned.size;
+  const accuracy = state.answersTotal ? Math.round((state.answersCorrect / state.answersTotal) * 100) : 100;
+  $('#stat-accuracy').textContent = `${accuracy}%`;
+  $('#stat-due').textContent = srsDueSet().length;
+  $('#stat-streak').textContent = state.streak;
+  $('#version').textContent = 'v2.0.0';
+  unlockAchievements();
+}
 
-  $('#btn-start').onclick = () => { state.mode = $('#mode-select').value; selectSet(); nextCard(); };
-  $('#btn-next').onclick = () => nextCard();
-  $('#btn-reveal').onclick = () => { $('#feedback').textContent = 'Lösung: ' + $('#prompt').dataset.answer; };
-  $('#btn-say').onclick = () => speak($('#prompt').textContent, 'ru-RU');
-  $('#answer').addEventListener('keydown', e => { if (e.key==='Enter') checkAnswer($('#answer').value, $('#prompt').dataset.answer, state.currentSet[state.currentIndex]); });
-
-  $('#btn-alpha-quiz').onclick = () => startAlphabetQuiz();
-  $('#btn-alpha-audio').onclick = () => {
-    const sel = $('.alpha-item.selected'); if (sel) speak(sel.dataset.ru, 'ru-RU');
-  };
-
-  $('#btn-due').onclick = () => startDuePractice();
-  $('#practice .actions').addEventListener('click', e => {
-    const g = e.target.dataset.grade; if (!g) return;
-    gradePractice(Number(g));
+function unlockAchievements() {
+  const container = $('#achievements');
+  if (!container) return;
+  ACHIEVEMENTS.forEach((ach) => {
+    if (ach.test(state)) {
+      state.achievements[ach.id] = state.achievements[ach.id] || Date.now();
+    }
   });
-
-  $('#btn-import').onclick = () => $('#file-input').click();
-  $('#file-input').onchange = async (e) => {
-    const file = e.target.files[0]; if (!file) return;
-    const text = await file.text();
-    try {
-      const data = JSON.parse(text);
-      if (!Array.isArray(data)) throw new Error('JSON muss ein Array sein.');
-      state.dataset = data;
-      state.categories = [...new Set(data.map(x=>x.cat))];
-      buildCategories();
-      save();
-      alert('Import erfolgreich.');
-    } catch(err){
-      alert('Fehler beim Import: '+err.message);
-    }
-  };
-  $('#btn-export').onclick = () => {
-    const blob = new Blob([JSON.stringify(state.dataset, null, 2)], {type:'application/json'});
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url; a.download = 'vocab-export.json'; a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  $('#btn-voice-scan').onclick = scanVoices;
-  $('#voice-select').onchange = e => {
-    const idx = Number(e.target.value);
-    state.voice = state.voices[idx] || null; save();
-  };
-
-  $('#btn-reset').onclick = () => {
-    if (confirm('Wirklich alles löschen?')){
-      localStorage.removeItem(STORAGE_KEY);
-      location.reload();
-    }
-  };
+  container.innerHTML = '';
+  ACHIEVEMENTS.forEach((ach) => {
+    const unlocked = Boolean(state.achievements[ach.id]);
+    const card = document.createElement('div');
+    card.className = 'achievement' + (unlocked ? ' unlocked' : '');
+    card.innerHTML = `<strong>${ach.title}</strong><p>${ach.desc}</p>`;
+    container.appendChild(card);
+  });
 }
 
-/* Theme */
-function themeApply(){
-  document.body.classList.toggle('light', !state.dark);
-  document.body.classList.toggle('dark', state.dark);
-  $('#toggle-dark').checked = state.dark;
-}
-
-/* Alphabet */
-async function buildAlphabetGrid(){
-  const alpha = await fetch('data/alphabet.ru.json').then(r=>r.json());
-  const grid = $('#alphabet-grid'); grid.innerHTML = '';
-  alpha.forEach(ch => {
+function buildAlphabetGrid() {
+  const grid = $('#alphabet-grid');
+  if (!grid) return;
+  grid.innerHTML = '';
+  ALPHABET.forEach((ch) => {
     const div = document.createElement('div');
     div.className = 'alpha-item';
     div.dataset.ru = ch.ru;
     div.innerHTML = `<strong lang="ru">${ch.ru}</strong><small>${ch.name}</small>`;
     div.onclick = () => {
-      $$('.alpha-item').forEach(x=>x.classList.remove('selected'));
+      $$('.alpha-item').forEach((x) => x.classList.remove('selected'));
       div.classList.add('selected');
       speak(ch.ru, 'ru-RU');
     };
@@ -303,115 +1426,143 @@ async function buildAlphabetGrid(){
   });
 }
 
-function startAlphabetQuiz(){
+function startAlphabetQuiz() {
   const items = $$('.alpha-item');
   if (!items.length) return;
-  const idx = Math.floor(Math.random()*items.length);
+  const idx = Math.floor(Math.random() * items.length);
   items[idx].click();
 }
 
-/* Audio TTS + simple SFX */
-function scanVoices(){
+function scanVoices() {
   const voices = speechSynthesis.getVoices();
-  if (!voices.length){
+  if (!voices.length) {
     speechSynthesis.onvoiceschanged = scanVoices;
     return;
   }
-  state.voices = voices.filter(v => v.lang.toLowerCase().startsWith('ru'));
-  const sel = $('#voice-select');
-  sel.innerHTML = '';
-  state.voices.forEach((v, i) => {
+  state.voices = voices.filter((voice) => voice.lang.toLowerCase().startsWith('ru'));
+  const select = $('#voice-select');
+  if (!select) return;
+  select.innerHTML = '';
+  state.voices.forEach((voice, index) => {
     const opt = document.createElement('option');
-    opt.value = String(i); opt.textContent = `${v.name} (${v.lang})`;
-    sel.appendChild(opt);
+    opt.value = String(index);
+    opt.textContent = `${voice.name} (${voice.lang})`;
+    select.appendChild(opt);
   });
-  if (state.voice){
-    const idx = state.voices.findIndex(v => v.name === state.voice.name);
-    sel.value = String(idx);
+  if (state.voice) {
+    const idx = state.voices.findIndex((v) => v.name === state.voice.name);
+    if (idx >= 0) select.value = String(idx);
   }
 }
 
-function speak(text, lang='ru-RU'){
+function speak(text, lang = 'ru-RU') {
   if (!text) return;
-  const u = new SpeechSynthesisUtterance(text);
-  if (state.voice) u.voice = state.voice;
-  u.lang = lang;
-  speechSynthesis.speak(u);
+  const utterance = new SpeechSynthesisUtterance(text);
+  if (state.voice) utterance.voice = state.voice;
+  utterance.lang = lang;
+  speechSynthesis.speak(utterance);
 }
 
-function ping(ok){
+function ping(ok) {
   if (!state.sfx) return;
   try {
     const ctx = new (window.AudioContext || window.webkitAudioContext)();
-    const o = ctx.createOscillator();
-    const g = ctx.createGain();
-    o.type = ok ? 'triangle' : 'sawtooth';
-    o.frequency.value = ok ? 660 : 220;
-    g.gain.value = 0.0001;
-    o.connect(g); g.connect(ctx.destination);
-    o.start();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = ok ? 'triangle' : 'sawtooth';
+    osc.frequency.value = ok ? 720 : 240;
+    gain.gain.value = 0.0001;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
     const t = ctx.currentTime;
-    g.gain.exponentialRampToValueAtTime(0.05, t+0.01);
-    g.gain.exponentialRampToValueAtTime(0.0001, t+0.25);
-    o.stop(t+0.26);
-  } catch {}
-}
-
-/* Confetti (tiny) */
-function confetti(){
-  const n = 20;
-  for (let i=0;i<n;i++){
-    const s = document.createElement('span');
-    s.textContent = '•';
-    s.style.position='fixed';
-    s.style.left = Math.random()*100+'vw';
-    s.style.top = '10px';
-    s.style.fontSize = (8+Math.random()*16)+'px';
-    s.style.opacity = '0.9';
-    s.style.pointerEvents='none';
-    s.style.transition='transform 0.9s ease, opacity 0.9s ease';
-    document.body.appendChild(s);
-    requestAnimationFrame(()=>{
-      s.style.transform = `translateY(${60+Math.random()*120}vh) rotate(${Math.random()*360}deg)`;
-      s.style.opacity = '0';
-    });
-    setTimeout(()=>s.remove(), 1000);
+    gain.gain.exponentialRampToValueAtTime(0.05, t + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.25);
+    osc.stop(t + 0.26);
+  } catch (err) {
+    console.warn('Audio konnte nicht abgespielt werden:', err);
   }
 }
 
-/* Simple chart without libs */
-function drawChartDummy(){
-  const can = $('#chart-dummy');
-  const ctx = can.getContext('2d');
-  ctx.clearRect(0,0,can.width,can.height);
+function confetti() {
+  const n = 22;
+  for (let i = 0; i < n; i += 1) {
+    const piece = document.createElement('span');
+    piece.style.position = 'fixed';
+    piece.style.left = Math.random() * 100 + 'vw';
+    piece.style.top = '10px';
+    piece.style.width = `${4 + Math.random() * 6}px`;
+    piece.style.height = `${10 + Math.random() * 14}px`;
+    piece.style.borderRadius = '2px';
+    piece.style.background = `linear-gradient(${Math.random() * 180}deg, hsla(${Math.random() * 360}, 75%, 65%, 0.9), hsla(${Math.random() * 360}, 85%, 55%, 0.9))`;
+    piece.style.pointerEvents = 'none';
+    piece.style.opacity = '0.9';
+    piece.style.transition = 'transform 1s ease, opacity 1s ease';
+    document.body.appendChild(piece);
+    requestAnimationFrame(() => {
+      piece.style.transform = `translateY(${60 + Math.random() * 120}vh) rotate(${Math.random() * 360}deg)`;
+      piece.style.opacity = '0';
+    });
+    setTimeout(() => piece.remove(), 1100);
+  }
+}
+
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
+function drawChartDummy() {
+  const canvas = $('#chart-dummy');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
   ctx.lineWidth = 2;
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  gradient.addColorStop(0, 'rgba(255,255,255,0.35)');
+  gradient.addColorStop(1, 'rgba(255,255,255,0.05)');
+  ctx.fillStyle = gradient;
+  const baseY = canvas.height - 40;
   ctx.beginPath();
-  const pts = [...Array(14)].map((_,i)=>({x: i*(can.width/13), y: 20 + Math.sin(i/2)*20 + 100 + Math.random()*20}));
-  ctx.moveTo(pts[0].x, pts[0].y);
-  pts.forEach(p=>ctx.lineTo(p.x,p.y));
+  const points = [...Array(14)].map((_, i) => ({ x: i * (canvas.width / 13), y: baseY - Math.sin(i / 2) * 30 - Math.random() * 25 }));
+  ctx.moveTo(points[0].x, canvas.height);
+  points.forEach((p) => ctx.lineTo(p.x, p.y));
+  ctx.lineTo(points[points.length - 1].x, canvas.height);
+  ctx.closePath();
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(255,255,255,0.55)';
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  points.forEach((p) => ctx.lineTo(p.x, p.y));
   ctx.stroke();
 }
 
-/* Install (PWA) */
-function registerSW(){
-  if ('serviceWorker' in navigator){
-    navigator.serviceWorker.register('sw.js');
+function registerSW() {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('sw.js').catch((err) => console.warn('SW Registrierung fehlgeschlagen', err));
   }
 }
-let deferredPrompt=null;
-function setupInstall(){
-  window.addEventListener('beforeinstallprompt', (e)=>{
-    e.preventDefault();
-    deferredPrompt = e;
-    $('#btn-install').style.display = 'inline-block';
+
+let deferredPrompt = null;
+function setupInstall() {
+  const installBtn = $('#btn-install');
+  if (installBtn) installBtn.style.display = 'none';
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+    $('#btn-install').style.display = 'inline-flex';
   });
-  $('#btn-install').onclick = async () => {
-    if (!deferredPrompt) return;
-    deferredPrompt.prompt();
-    await deferredPrompt.userChoice;
-    deferredPrompt = null;
-  };
+  if (installBtn) {
+    installBtn.onclick = async () => {
+      if (!deferredPrompt) return;
+      deferredPrompt.prompt();
+      await deferredPrompt.userChoice;
+      deferredPrompt = null;
+    };
+  }
 }
 
-/* Start */
 window.addEventListener('load', init);

--- a/index.html
+++ b/index.html
@@ -11,25 +11,211 @@
   <link rel="preload" href="style.css" as="style">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <header class="app-header">
-    <h1>Russisch Vokabel-App Deluxe</h1>
-    <div class="header-actions">
-      <button id="btn-dark" class="ghost" aria-label="Theme umschalten">🌓</button>
-      <button id="btn-audio" class="ghost" aria-label="Audio umschalten">🔊</button>
-      <button id="btn-install" class="primary" aria-label="App installieren">Installieren</button>
+<body data-theme="midnight">
+  <svg class="sprite" aria-hidden="true">
+    <symbol id="icon-palette" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 2a10 10 0 1 0 0 20h2.25a2.75 2.75 0 0 0 0-5.5h-1a2.25 2.25 0 0 1 0-4.5h1A5.75 5.75 0 0 0 19 6.25C19 3.9 17.1 2 14.75 2Zm-3.5 5a1.75 1.75 0 1 1-3.5 0 1.75 1.75 0 0 1 3.5 0Zm3-2a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Zm4 3.5a1.75 1.75 0 1 1 0-3.5 1.75 1.75 0 0 1 0 3.5Zm-1 9.5a1 1 0 1 1 0-2h1.75a1 1 0 0 1 0 2Z" />
+    </symbol>
+    <symbol id="icon-audio" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M4 9v6h3l4 4V5L7 9H4Zm11.5 3a3.5 3.5 0 0 0-2-3.16v6.32a3.5 3.5 0 0 0 2-3.16Zm2.5 0a6 6 0 0 0-3.5-5.47v2.28a3.75 3.75 0 0 1 0 6.38v2.28A6 6 0 0 0 18 12Z" />
+    </symbol>
+    <symbol id="icon-audio-off" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M7.17 9 4 12.17V9h3.17ZM20.3 5.7 18.9 4.3 4.29 18.9l1.41 1.41 2.47-2.47L11 21l4-4v-3.76l2.7 2.7c.18-.38.3-.8.3-1.24a3.5 3.5 0 0 0-3.5-3.5h-.5l6.3 6.3 1.41-1.41-1.72-1.72-.7-.7-3.06-3.05L20.3 5.7ZM15.5 6.53v2.28a3.75 3.75 0 0 1 2.42 3.52c0 .13-.01.26-.02.38l1.63 1.63a6 6 0 0 0-4.03-7.81Z" />
+    </symbol>
+    <symbol id="icon-install" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 3a1 1 0 0 0-1 1v9.59l-2.3-2.3-1.4 1.42 4.7 4.7 4.7-4.7-1.4-1.42-2.3 2.3V4a1 1 0 0 0-1-1Zm-7 14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-2h-2v2H7v-2H5v2Z" />
+    </symbol>
+    <symbol id="icon-sun" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 5a1 1 0 0 1-1-1V2h2v2a1 1 0 0 1-1 1Zm0 14a1 1 0 0 1 1 1v2h-2v-2a1 1 0 0 1 1-1Zm7-7a1 1 0 0 1 1-1h2v2h-2a1 1 0 0 1-1-1ZM3 11H1v2h2a1 1 0 0 1 0-2Zm13.66-5.66L18.78 3.2l1.41 1.41-2.12 2.13-1.41-1.41ZM5.21 18.79l-1.41-1.41 2.12-2.13 1.41 1.41-2.12 2.13ZM18.78 20.8l-2.12-2.13 1.41-1.41 2.12 2.12-1.41 1.42ZM6.34 6.34 4.21 4.21 5.63 2.8l2.12 2.13-1.41 1.41ZM12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10Z" />
+    </symbol>
+    <symbol id="icon-moon" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79Z" />
+    </symbol>
+    <symbol id="icon-palace" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M4 10V8l8-5 8 5v2h-2v10h-4v-6h-4v6H6V10H4Zm5 0h6V7.7L12 5.6 9 7.7V10Z" />
+    </symbol>
+    <symbol id="icon-forest" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M5 19h14l-3.5-6H18L12 3l-4 7h2.5L5 19Zm-1 2a1 1 0 0 1 0-2h16a1 1 0 1 1 0 2H4Z" />
+    </symbol>
+    <symbol id="icon-masks" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M3 4a1 1 0 0 1 1-1h7a1 1 0 0 1 1 1v6c0 3.31-2.24 6-5 6S2 13.31 2 10V4Zm2 3a1 1 0 1 0 0 2c.55 0 1-.45 1-1s-.45-1-1-1Zm4 0a1 1 0 1 0 0 2c.55 0 1-.45 1-1s-.45-1-1-1Zm-1 5c.87 0 1.64-.3 2.26-.8A3 3 0 0 1 8 12a3 3 0 0 1-2.26-.8A3.98 3.98 0 0 0 8 12Zm6-8h7a1 1 0 0 1 1 1v5c0 3.87-2.69 7-6 7s-6-3.13-6-7V5a1 1 0 0 1 1-1Zm2 3a1 1 0 1 0 0 2c.55 0 1-.45 1-1s-.45-1-1-1Zm4 0a1 1 0 1 0 0 2c.55 0 1-.45 1-1s-.45-1-1-1Zm-2 6c1.17 0 2.2-.45 2.95-1.18A4 4 0 0 1 18 15a4 4 0 0 1-2.95-1.18A3.6 3.6 0 0 0 18 15Z" />
+    </symbol>
+    <symbol id="icon-sunrise" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 4a1 1 0 0 1 1 1v1.05A6.02 6.02 0 0 1 18 12h-2a4 4 0 1 0-8 0H6a6.02 6.02 0 0 1 5-6.95V5a1 1 0 0 1 1-1Zm-8 8h2v2H4v-2Zm14 0h2v2h-2v-2Zm-9 6h6v2H9v-2Zm-4-2h14v2H5v-2Z" />
+    </symbol>
+    <symbol id="icon-compass-star" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 2 9.5 9.5 2 12l7.5 2.5L12 22l2.5-7.5L22 12l-7.5-2.5L12 2Zm0 5.1 1.06 3.18L16.24 11.4l-3.18 1.06L12 15.64l-1.06-3.18L7.76 11.4l3.18-1.12L12 7.1Z" />
+    </symbol>
+    <symbol id="icon-snowflake" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M11 2h2v5.17l1.59-1.58L16 7l-4 4-4-4 1.41-1.41L11 7.17V2Zm-6.24 3.76 1.41-1.41L9 6.17 7.59 7.59 4.76 5.76ZM17 6.17l2.83-1.82 1.41 1.41L18.41 7.59 17 6.17ZM11 18.83V24h2v-5.17l1.59 1.58L16 17l-4-4-4 4 1.41 1.41L11 18.83ZM4.76 18.24l2.83-1.83L9 17.83 6.17 20.66l-1.41-1.41Zm12.24 0 2.83 1.83-1.41 1.41L15 17.83l1.41-1.41ZM2 11h5.17L5.59 9.41 7 8l4 4-4 4-1.41-1.41L2 13v-2Zm20 2h-5.17l1.58 1.59L17 16l-4-4 4-4 1.41 1.41L22 11v2Z" />
+    </symbol>
+    <symbol id="icon-porcelain" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M18 7h2a3 3 0 0 1 0 6h-1.18A6 6 0 0 1 6 14h10a4 4 0 0 0 4-4V7Zm-2-2H4v5a6 6 0 0 0 6 6 6 6 0 0 0 6-6V5Zm2 12H4a1 1 0 0 0 0 2h14a1 1 0 1 0 0-2Z" />
+    </symbol>
+    <symbol id="icon-river" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M3 7c1.5 0 1.5-1 3-1s1.5 1 3 1 1.5-1 3-1 1.5 1 3 1 1.5-1 3-1v2c-1.5 0-1.5 1-3 1s-1.5-1-3-1-1.5 1-3 1-1.5-1-3-1-1.5 1-3 1V7Zm0 6c1.5 0 1.5-1 3-1s1.5 1 3 1 1.5-1 3-1 1.5 1 3 1 1.5-1 3-1v2c-1.5 0-1.5 1-3 1s-1.5-1-3-1-1.5 1-3 1-1.5-1-3-1-1.5 1-3 1v-2Z" />
+    </symbol>
+    <symbol id="icon-troika" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M3 14h2l1.5-4h11L19 14h2a2 2 0 1 1 0 4h-1.09a3.5 3.5 0 0 1-6.82 0H9.91a3.5 3.5 0 0 1-6.82 0H3v-4Zm3.5 4a1.5 1.5 0 0 0 2.83 0H6.5Zm7 0a1.5 1.5 0 0 0 2.83 0H13.5Zm3.17-6H7.33l-.75 2h10.84l-.75-2Z" />
+    </symbol>
+    <symbol id="icon-book" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M4 5a2 2 0 0 1 2-2h5v16H6a2 2 0 0 0-2 2V5Zm9-2h5a2 2 0 0 1 2 2v16a2 2 0 0 0-2-2h-5V3Z" />
+    </symbol>
+    <symbol id="icon-compass" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm3.5 6.5-2 5.5-5.5 2 2-5.5 5.5-2Z" />
+    </symbol>
+    <symbol id="icon-globe" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 2c1.1 0 2.15.3 3.05.85-.68.77-1.24 1.88-1.54 3.15H10.5c-.3-1.27-.86-2.38-1.54-3.15A7.96 7.96 0 0 1 12 4Zm-6 8c0-.7.07-1.38.2-2h3.38c-.05.65-.08 1.32-.08 2s.03 1.35.08 2H6.2a8.1 8.1 0 0 1-.2-2Zm2.96 4.15c.68-.77 1.24-1.88 1.54-3.15h3.01c.3 1.27.86 2.38 1.54 3.15A7.96 7.96 0 0 1 12 20a7.96 7.96 0 0 1-3.04-.85ZM13.5 12c0-.68-.03-1.35-.08-2h3.38c.13.62.2 1.3.2 2s-.07 1.38-.2 2h-3.38c.05-.65.08-1.32.08-2Zm1.46-6.85A7.96 7.96 0 0 1 18 12a8.1 8.1 0 0 1-.2 2h-3.38c.05-.65.08-1.32.08-2s-.03-1.35-.08-2h3.38c-.13-.62-.2-1.3-.2-2 0-1.59-.47-3.07-1.26-4.27ZM7.26 5.15C6.47 6.35 6 7.83 6 9.42c0 .7.07 1.38.2 2h3.38c-.05-.65-.08-1.32-.08-2s.03-1.35.08-2H6.2c-.13-.62-.2-1.3-.2-2 0-1.59.47-3.07 1.26-4.27Z" />
+    </symbol>
+    <symbol id="icon-laurel" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 3c-2.21 0-4 1.79-4 4 0 1.5 1.47 3.93 4 7.2 2.53-3.27 4-5.7 4-7.2 0-2.21-1.79-4-4-4Zm0 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm-6 9.5c0 1.93 1.57 3.5 3.5 3.5h1.03a34 34 0 0 1-2.34-3.63c-.74-1.3-1.3-2.49-1.68-3.53-.31.66-.51 1.43-.51 2.16Zm12 0c0-.73-.2-1.5-.51-2.16-.38 1.04-.94 2.23-1.68 3.53A34 34 0 0 1 13.47 20h1.03c1.93 0 3.5-1.57 3.5-3.5Z" />
+    </symbol>
+    <symbol id="icon-quill" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M20.2 3.8a3.2 3.2 0 0 0-4.52 0L5 14.48l-.96 4.8 4.8-.96L20.2 8.32a3.2 3.2 0 0 0 0-4.52Zm-8.46 13.14-1.73.35.35-1.73 9.7-9.7c.46-.46 1.2-.46 1.66 0s.46 1.2 0 1.66l-9.98 9.42Z" />
+      <path fill="currentColor" d="M5 21h6v-2H5a1 1 0 1 0 0 2Z" />
+    </symbol>
+    <symbol id="icon-cyrillic" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M5 4h14v3h-4v13h-3V7H8v13H5V4Z" />
+      <path fill="currentColor" d="M19 11v2c-1.8 0-3 .9-3 2.4S17.2 18 19 18v2c-3.1 0-5-1.9-5-4.6 0-2.88 2-4.4 5-4.4Z" />
+    </symbol>
+    <symbol id="icon-target" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 17a7 7 0 1 1 0-14 7 7 0 0 1 0 14Z" />
+      <path fill="currentColor" d="M12 7a5 5 0 1 0 0 10 5 5 0 0 0 0-10Zm0 7a2 2 0 1 1 0-4 2 2 0 0 1 0 4Z" />
+    </symbol>
+    <symbol id="icon-chart" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M4 4h2v16H4V4Zm14 5h2v11h-2V9Zm-7 3h2v8h-2v-8Zm-4-2h2v10H7V10Zm8-6h2v16h-2V4Z" />
+    </symbol>
+    <symbol id="icon-gear" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M19.14 12.94c.04-.31.06-.62.06-.94s-.02-.63-.06-.94l2.03-1.58a.5.5 0 0 0 .12-.65l-1.92-3.32a.5.5 0 0 0-.61-.22l-2.39.96a7 7 0 0 0-1.63-.94l-.36-2.54A.5.5 0 0 0 14.9 2h-3.8a.5.5 0 0 0-.5.43l-.36 2.54a7 7 0 0 0-1.63.94l-2.39-.96a.5.5 0 0 0-.61.22L3.69 8.49a.5.5 0 0 0 .12.65l2.03 1.58c-.04.31-.06.62-.06.94s.02.63.06.94l-2.03 1.58a.5.5 0 0 0-.12.65l1.92 3.32c.14.24.44.34.7.22l2.39-.96c.5.38 1.05.7 1.63.94l.36 2.54c.05.26.26.43.5.43h3.8a.5.5 0 0 0 .5-.43l.36-2.54c.58-.24 1.13-.56 1.63-.94l2.39.96c.26.12.56.02.7-.22l1.92-3.32a.5.5 0 0 0-.12-.65l-2.03-1.58ZM12 15a3 3 0 1 1 0-6 3 3 0 0 1 0 6Z" />
+    </symbol>
+    <symbol id="icon-shuffle" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M17 3h4v4h-2V5.41l-4.3 4.3-1.41-1.41L17 3Zm-6.71 6.29L7 12.59 3.71 9.29 2.29 10.7 7 15.41l4.71-4.7-1.42-1.42ZM17 21l4-4h-4v-2h6v6h-2v-2.59l-4.3 4.3-1.41-1.41L17 21Zm-9-3 3.29-3.29-1.41-1.41L6 16.59 3.71 14.3 2.29 15.7 6 19.41 8 17.41Z" />
+    </symbol>
+    <symbol id="icon-play" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M8 5.14v13.72L19 12 8 5.14Z" />
+    </symbol>
+    <symbol id="icon-eye" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 5C7 5 2.73 8.11 1 12c1.73 3.89 6 7 11 7s9.27-3.11 11-7c-1.73-3.89-6-7-11-7Zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10Zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z" />
+    </symbol>
+    <symbol id="icon-volume" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M5 9v6h3l4 4V5L8 9H5Zm11.5 3a3.5 3.5 0 0 0-2-3.16v6.32a3.5 3.5 0 0 0 2-3.16Zm2.5 0a6 6 0 0 0-3.5-5.47v2.28a3.75 3.75 0 0 1 0 6.38v2.28A6 6 0 0 0 19 12Z" />
+    </symbol>
+    <symbol id="icon-next" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M5 5v14l9-7-9-7Zm10 0v14h2V5h-2Z" />
+    </symbol>
+    <symbol id="icon-refresh" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M17.65 6.35A7.95 7.95 0 0 0 12 4V1L7 6l5 5V8a5 5 0 1 1-5 5H5a7 7 0 1 0 12.65-6.65Z" />
+    </symbol>
+    <symbol id="icon-star" viewBox="0 0 24 24">
+      <path fill="currentColor" d="m12 3 2.6 5.27L20.5 9l-4 3.9.94 5.5L12 15.9 6.56 18.4 7.5 12.9 3.5 9l5.9-.73L12 3Z" />
+    </symbol>
+    <symbol id="icon-flag" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M5 3a1 1 0 0 0-1 1v18h2v-6h9l1.5 3H21l-2-4 2-4h-4.5L15 15H6V4a1 1 0 0 0-1-1Z" />
+    </symbol>
+    <symbol id="icon-download" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 3a1 1 0 0 0-1 1v8H8l4 5 4-5h-3V4a1 1 0 0 0-1-1Zm-7 14h2v2h10v-2h2v4H5v-4Z" />
+    </symbol>
+    <symbol id="icon-upload" viewBox="0 0 24 24">
+      <path fill="currentColor" d="M12 3 8 8h3v8h2V8h3l-4-5Zm-7 14h2v2h10v-2h2v4H5v-4Z" />
+    </symbol>
+  </svg>
+
+  <audio id="theme-music" preload="auto" loop aria-hidden="true"></audio>
+
+  <div id="landing" class="landing" role="dialog" aria-modal="true" aria-labelledby="landing-title">
+    <div class="landing__backdrop"></div>
+    <div class="landing__content">
+      <div class="landing__layout">
+        <div class="landing__hero">
+          <header class="landing__header">
+            <h1 id="landing-title">Russisch Vokabel-App Deluxe</h1>
+            <p>Wähle zunächst eine Stimmung und dein Lernniveau, bevor du in die Welt der russischen Worte eintauchst.</p>
+          </header>
+          <ul class="landing__highlights" role="list">
+            <li>
+              <svg class="icon" aria-hidden="true"><use href="#icon-palette"></use></svg>
+              <span>Zehn Atmosphären von Midnight Aurora bis Troika Trail</span>
+            </li>
+            <li>
+              <svg class="icon" aria-hidden="true"><use href="#icon-book"></use></svg>
+              <span>Kuratierte Dialog-Vokabellisten für Klassen 7–10</span>
+            </li>
+            <li>
+              <svg class="icon" aria-hidden="true"><use href="#icon-audio"></use></svg>
+              <span>Dynamische Musik &amp; Vorlesefunktion begleiten dich</span>
+            </li>
+          </ul>
+        </div>
+        <div class="landing__panels">
+          <section class="landing__section">
+            <h2>Stimmung &amp; Flair</h2>
+            <div id="landing-theme-grid" class="theme-grid" aria-label="Theme-Auswahl"></div>
+          </section>
+          <section class="landing__section">
+            <h2>Lernpfad</h2>
+            <div id="landing-grade-grid" class="grade-grid" aria-label="Schwierigkeitsgrade"></div>
+          </section>
+        </div>
+      </div>
+      <div class="landing__note">
+        <svg class="icon" aria-hidden="true"><use href="#icon-install"></use></svg>
+        <p>Eigene Wortlisten sind optional – die Dialog-Repertoires liefern hunderte Begriffe, die du später jederzeit erweitern kannst.</p>
+      </div>
+      <button id="landing-enter" class="primary large">
+        <span>Ins Training starten</span>
+      </button>
     </div>
-  </header>
+  </div>
 
-  <nav class="tabs" role="tablist" aria-label="Hauptnavigation">
-    <button class="tab active" data-tab="learn" role="tab" aria-selected="true">Lernen</button>
-    <button class="tab" data-tab="alphabet" role="tab" aria-selected="false">Alphabet</button>
-    <button class="tab" data-tab="practice" role="tab" aria-selected="false">Üben</button>
-    <button class="tab" data-tab="stats" role="tab" aria-selected="false">Statistik</button>
-    <button class="tab" data-tab="settings" role="tab" aria-selected="false">Einstellungen</button>
-  </nav>
+  <div class="app-shell">
+    <header class="app-header">
+      <div class="brand">
+        <span class="brand__mark">РЖ</span>
+        <div class="brand__copy">
+          <span class="brand__title">Russisch Vokabel-App Deluxe</span>
+          <span class="brand__subtitle">Lernen mit Stil</span>
+        </div>
+      </div>
+      <div class="header-actions">
+        <button id="btn-theme" class="ghost" aria-label="Theme wechseln">
+          <svg class="icon"><use href="#icon-palette"></use></svg>
+          <span class="btn-label">Theme</span>
+        </button>
+        <button id="btn-audio" class="ghost" aria-label="Sound und Musik umschalten">
+          <svg class="icon"><use id="icon-audio-use" href="#icon-audio"></use></svg>
+          <span class="btn-label">Audio &amp; Musik</span>
+        </button>
+        <button id="btn-install" class="primary" aria-label="App installieren">
+          <svg class="icon"><use href="#icon-install"></use></svg>
+          <span class="btn-label">Installieren</span>
+        </button>
+      </div>
+    </header>
 
-  <main>
+    <nav class="tabs" role="tablist" aria-label="Hauptnavigation">
+      <button class="tab active" data-tab="learn" role="tab" aria-selected="true">
+        <svg class="icon" aria-hidden="true"><use href="#icon-quill"></use></svg>
+        <span>Lernen</span>
+      </button>
+      <button class="tab" data-tab="alphabet" role="tab" aria-selected="false">
+        <svg class="icon" aria-hidden="true"><use href="#icon-cyrillic"></use></svg>
+        <span>Alphabet</span>
+      </button>
+      <button class="tab" data-tab="practice" role="tab" aria-selected="false">
+        <svg class="icon" aria-hidden="true"><use href="#icon-target"></use></svg>
+        <span>Üben</span>
+      </button>
+      <button class="tab" data-tab="stats" role="tab" aria-selected="false">
+        <svg class="icon" aria-hidden="true"><use href="#icon-chart"></use></svg>
+        <span>Statistik</span>
+      </button>
+      <button class="tab" data-tab="settings" role="tab" aria-selected="false">
+        <svg class="icon" aria-hidden="true"><use href="#icon-gear"></use></svg>
+        <span>Einstellungen</span>
+      </button>
+    </nav>
+
+    <main>
     <section id="learn" class="panel visible">
       <div class="toolbar">
         <select id="category-select"></select>
@@ -38,16 +224,22 @@
           <option value="type">Eintippen</option>
           <option value="audio">Hören → Tippen</option>
         </select>
-        <button id="btn-start" class="primary">Start</button>
+        <button id="btn-start" class="primary"><svg class="icon" aria-hidden="true"><use href="#icon-play"></use></svg><span>Start</span></button>
       </div>
       <div id="card" class="card">
+        <div class="prompt-scene">
+          <div id="prompt-visual" class="prompt-visual" aria-hidden="true"></div>
+          <div class="prompt-meta">
+            <span id="prompt-category" class="tag" hidden></span>
+            <button id="btn-say" class="ghost circle" type="button" aria-label="Russischen Satz anhören"><svg class="icon" aria-hidden="true"><use href="#icon-volume"></use></svg></button>
+          </div>
+        </div>
         <div id="prompt" class="prompt"></div>
         <input id="answer" class="answer" type="text" inputmode="latin-name" placeholder="Antwort hier...">
         <div id="choices" class="choices"></div>
         <div class="actions">
-          <button id="btn-reveal" class="ghost">Lösung zeigen</button>
-          <button id="btn-say" class="ghost">Vorlesen</button>
-          <button id="btn-next" class="primary">Weiter</button>
+          <button id="btn-reveal" class="ghost"><svg class="icon" aria-hidden="true"><use href="#icon-eye"></use></svg><span>Lösung zeigen</span></button>
+          <button id="btn-next" class="primary"><svg class="icon" aria-hidden="true"><use href="#icon-next"></use></svg><span>Weiter</span></button>
         </div>
         <div id="feedback" class="feedback" aria-live="polite"></div>
       </div>
@@ -56,25 +248,32 @@
 
     <section id="alphabet" class="panel">
       <div class="toolbar">
-        <button id="btn-alpha-quiz" class="primary">Alphabet-Quiz starten</button>
-        <button id="btn-alpha-audio" class="ghost">Buchstabe vorlesen</button>
+        <button id="btn-alpha-quiz" class="primary"><svg class="icon" aria-hidden="true"><use href="#icon-target"></use></svg><span>Alphabet-Quiz starten</span></button>
+        <button id="btn-alpha-audio" class="ghost"><svg class="icon" aria-hidden="true"><use href="#icon-volume"></use></svg><span>Buchstabe vorlesen</span></button>
       </div>
       <div id="alphabet-grid" class="grid"></div>
     </section>
 
     <section id="practice" class="panel">
       <div class="toolbar">
-        <button id="btn-due" class="primary">Fällige Wiederholungen</button>
-        <button id="btn-hard" class="ghost">Schwer markieren</button>
-        <button id="btn-fav" class="ghost">Zu Favoriten</button>
+        <button id="btn-due" class="primary"><svg class="icon" aria-hidden="true"><use href="#icon-refresh"></use></svg><span>Fällige Wiederholungen</span></button>
+        <button id="btn-hard" class="ghost"><svg class="icon" aria-hidden="true"><use href="#icon-flag"></use></svg><span>Schwer markieren</span></button>
+        <button id="btn-fav" class="ghost"><svg class="icon" aria-hidden="true"><use href="#icon-star"></use></svg><span>Zu Favoriten</span></button>
       </div>
       <div id="practice-card" class="card compact">
+        <div class="prompt-scene">
+          <div id="practice-visual" class="prompt-visual" aria-hidden="true"></div>
+          <div class="prompt-meta">
+            <span id="practice-category" class="tag" hidden></span>
+            <button id="btn-practice-say" class="ghost circle" type="button" aria-label="Russischen Satz anhören"><svg class="icon" aria-hidden="true"><use href="#icon-volume"></use></svg></button>
+          </div>
+        </div>
         <div id="practice-prompt" class="prompt"></div>
         <input id="practice-answer" class="answer" type="text" placeholder="Antwort...">
         <div class="actions">
-          <button data-grade="0" class="outline">Falsch</button>
-          <button data-grade="3" class="outline">So lala</button>
-          <button data-grade="5" class="primary">Richtig</button>
+          <button data-grade="0" class="outline"><svg class="icon" aria-hidden="true"><use href="#icon-flag"></use></svg><span>Falsch</span></button>
+          <button data-grade="3" class="outline"><svg class="icon" aria-hidden="true"><use href="#icon-shuffle"></use></svg><span>So lala</span></button>
+          <button data-grade="5" class="primary"><svg class="icon" aria-hidden="true"><use href="#icon-star"></use></svg><span>Richtig</span></button>
         </div>
         <div id="practice-feedback" class="feedback"></div>
       </div>
@@ -93,10 +292,19 @@
 
     <section id="settings" class="panel">
       <h2>Einstellungen</h2>
-      <label class="toggle">
-        <input type="checkbox" id="toggle-dark">
-        <span>Dark Mode</span>
-      </label>
+
+      <div class="group">
+        <h3>Theme</h3>
+        <p class="muted">Wähle eine Atmosphäre, die zu deiner Lernstimmung passt.</p>
+        <div id="settings-theme-grid" class="theme-grid compact"></div>
+      </div>
+
+      <div class="group">
+        <h3>Schwierigkeitsgrad</h3>
+        <p class="muted">Passe dein Repertoire an Anfänger-, Fortgeschrittenen- oder Meister-Niveau an.</p>
+        <div id="settings-grade-grid" class="grade-grid compact"></div>
+      </div>
+
       <label class="toggle">
         <input type="checkbox" id="toggle-sfx" checked>
         <span>Soundeffekte</span>
@@ -108,29 +316,37 @@
 
       <div class="group">
         <h3>Vokabeln</h3>
-        <button id="btn-import" class="outline">Import JSON</button>
-        <button id="btn-export" class="outline">Export JSON</button>
-        <input type="file" id="file-input" accept="application/json" hidden>
+        <label class="toggle inline">
+          <input type="checkbox" id="toggle-custom-data">
+          <span>Eigene Wortliste verwenden</span>
+        </label>
+        <p class="muted small">Standardmäßig werden kuratierte Listen je nach Schwierigkeitsgrad verwendet. Aktiviere diese Option, um deine eigenen Wörter zu importieren.</p>
+        <div id="custom-data-tools" class="custom-data-tools hidden">
+          <button id="btn-import" class="outline"><svg class="icon" aria-hidden="true"><use href="#icon-upload"></use></svg><span>Import JSON</span></button>
+          <button id="btn-export" class="outline"><svg class="icon" aria-hidden="true"><use href="#icon-download"></use></svg><span>Export JSON</span></button>
+          <input type="file" id="file-input" accept="application/json" hidden>
+        </div>
       </div>
 
       <div class="group">
         <h3>Audio</h3>
-        <button id="btn-voice-scan" class="outline">Russische Stimmen suchen</button>
+        <button id="btn-voice-scan" class="outline"><svg class="icon" aria-hidden="true"><use href="#icon-volume"></use></svg><span>Russische Stimmen suchen</span></button>
         <select id="voice-select"></select>
         <small>Nutze Text-To-Speech des Browsers. Falls keine russische Stimme vorhanden ist, wird eine neutrale genutzt.</small>
       </div>
 
       <div class="group">
         <h3>Zurücksetzen</h3>
-        <button id="btn-reset" class="danger">Alle Daten löschen</button>
+        <button id="btn-reset" class="danger"><svg class="icon" aria-hidden="true"><use href="#icon-flag"></use></svg><span>Alle Daten löschen</span></button>
       </div>
     </section>
-  </main>
+    </main>
 
-  <footer class="app-footer">
-    <span>© 2025 Vokabel-App Deluxe</span>
-    <span id="version">v1.0.0</span>
-  </footer>
+    <footer class="app-footer">
+      <span>© 2025 Vokabel-App Deluxe</span>
+      <span id="version">v1.0.0</span>
+    </footer>
+  </div>
 
   <script src="app.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -2,154 +2,678 @@
 * { box-sizing: border-box; }
 html, body { height: 100%; }
 :root {
-  --bg: #0f0f10;
-  --fg: #e8e8ec;
-  --muted: #a0a3ad;
-  --primary: #6c8cff;
-  --primary-2: #90a7ff;
+  --bg: #070818;
+  --bg-grad: radial-gradient(circle at 20% 20%, rgba(111,142,255,0.35) 0%, transparent 55%), radial-gradient(circle at 80% 0%, rgba(255,100,180,0.28) 0%, transparent 60%), #05050f;
+  --bg-texture: radial-gradient(circle, rgba(255,255,255,0.08) 0%, transparent 60%);
+  --bg-art: none;
+  --bg-art-position: center;
+  --bg-art-filter: saturate(1.05);
+  --bg-art-opacity: 0.5;
+  --bg-art-size: cover;
+  --fg: #f6f7ff;
+  --muted: #aeb8dc;
+  --primary: #809bff;
+  --primary-2: #9cb4ff;
   --danger: #ff6c6c;
-  --card: #18181b;
-  --border: #2a2a2f;
-  --accent: #9b8cff;
+  --card: rgba(13,17,38,0.85);
+  --card-border: rgba(130,155,255,0.35);
+  --input-surface: rgba(15,20,38,0.78);
+  --input-border: rgba(255,255,255,0.12);
+  --border: rgba(255,255,255,0.1);
+  --accent: #b78cff;
+  --glass: rgba(8,12,32,0.55);
+  --shadow: 0 20px 45px rgba(5,8,23,0.45);
+  --shell-width: 1120px;
+  --shell-padding: clamp(18px, 4vw, 32px);
   font-variant-ligatures: none;
-}
-
-body.light {
-  --bg: #fafafc;
-  --fg: #0e0f12;
-  --muted: #5a5f6a;
-  --primary: #3a63ff;
-  --primary-2: #5778ff;
-  --danger: #d24545;
-  --card: #ffffff;
-  --border: #e6e7ec;
-  --accent: #6d59ff;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", "Arial", sans-serif;
-  background: var(--bg);
+  font-family: "Inter", "Segoe UI", "Noto Sans", system-ui, -apple-system, sans-serif;
+  font-size: clamp(1rem, 0.96rem + 0.28vw, 1.12rem);
+  line-height: 1.6;
+  background: var(--bg-grad, var(--bg));
+  background-color: var(--bg);
   color: var(--fg);
   text-rendering: optimizeLegibility;
+  position: relative;
+  min-height: 100vh;
+  overflow-x: hidden;
+  scroll-behavior: smooth;
 }
+
+.app-shell {
+  width: min(100%, var(--shell-width));
+  margin: 0 auto;
+  padding: 0 var(--shell-padding);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  position: relative;
+  z-index: 1;
+}
+
+body.no-scroll { overflow: hidden; }
+
+.app-shell::before {
+  content: "";
+  position: absolute;
+  inset: clamp(18px, 4vw, 32px);
+  border-radius: 36px;
+  border: 1px solid rgba(255,255,255,0.06);
+  background: rgba(6,10,24,0.4);
+  mix-blend-mode: lighten;
+  opacity: 0.35;
+  pointer-events: none;
+  z-index: -1;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+}
+
+body::before {
+  background-image: var(--bg-art);
+  background-size: var(--bg-art-size, cover);
+  background-position: var(--bg-art-position, center);
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  filter: var(--bg-art-filter, saturate(1));
+  opacity: var(--bg-art-opacity, 0.45);
+  z-index: -2;
+}
+
+body::after {
+  background: var(--bg-texture);
+  opacity: 0.28;
+  mix-blend-mode: screen;
+  z-index: -1;
+}
+
+@media (max-width: 900px) {
+  body::before {
+    background-attachment: scroll;
+    background-position: center top;
+    background-size: cover;
+  }
+}
+
+.sprite { display: none; }
 
 .app-header, .app-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border);
+  padding: 14px 20px;
+  background: linear-gradient(135deg, rgba(255,255,255,0.08), rgba(8,14,32,0.78));
+  backdrop-filter: blur(22px);
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 20px rgba(0,0,0,0.25);
 }
-.app-footer { border-top: 1px solid var(--border); border-bottom: none; }
 
-h1 { font-size: 20px; margin: 0; }
-h2 { margin-top: 0; }
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  border-radius: 22px;
+  margin-top: clamp(18px, 4vw, 28px);
+  border-bottom-color: var(--border);
+  flex-wrap: wrap;
+  gap: 16px;
+}
 
-.header-actions { display: flex; gap: 8px; }
+.tabs {
+  border-radius: 18px;
+  margin-top: 16px;
+}
+
+.app-footer {
+  margin-top: clamp(48px, 8vw, 72px);
+  border-radius: 18px;
+  gap: 12px;
+  padding: 12px 20px;
+  align-self: center;
+  position: static;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.brand__mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  background: linear-gradient(135deg, rgba(255,156,102,0.75), rgba(117,98,255,0.85));
+  color: #fff;
+  box-shadow: inset 0 1px 3px rgba(255,255,255,0.35);
+}
+
+.brand__copy { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.brand__title { font-size: clamp(1rem, 0.88rem + 0.45vw, 1.28rem); font-weight: 700; white-space: nowrap; }
+.brand__subtitle { font-size: clamp(0.7rem, 0.64rem + 0.18vw, 0.8rem); color: var(--muted); text-transform: uppercase; letter-spacing: 0.12em; }
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.header-actions button { flex: 0 0 auto; }
+.header-actions .btn-label { font-size: 0.82rem; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.icon {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tab .icon {
+  width: 18px;
+  height: 18px;
+}
+
+.tab span {
+  white-space: nowrap;
+}
 
 .primary, .ghost, .outline, .danger {
-  padding: 10px 14px;
-  border-radius: 10px;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 14px;
   border: 1px solid transparent;
   background: var(--primary);
-  color: white;
+  color: #fff;
   cursor: pointer;
   font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+  box-shadow: 0 12px 24px rgba(0,0,0,0.25);
 }
-.primary:hover { filter: brightness(1.05); }
-.ghost { background: transparent; border-color: var(--border); color: var(--fg); }
-.outline { background: transparent; border-color: var(--primary); color: var(--primary); }
-.danger { background: var(--danger); }
 
-.tabs { display: grid; grid-template-columns: repeat(5, 1fr); border-bottom: 1px solid var(--border); }
-.tab { padding: 12px; background: transparent; border: none; border-right: 1px solid var(--border); color: var(--muted); cursor: pointer; font-weight: 600; }
-.tab.active { color: var(--fg); border-bottom: 2px solid var(--primary); }
-
-main { padding: 16px; max-width: 1000px; margin: 0 auto; }
-.panel { display: none; }
-.panel.visible { display: block; }
-
-.toolbar { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 12px; }
-select, input[type="text"] {
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: var(--card);
+.primary:hover { filter: brightness(1.08); transform: translateY(-1px); }
+.ghost {
+  background: rgba(255,255,255,0.06);
   color: var(--fg);
-  min-width: 200px;
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: none;
 }
+.ghost:hover { border-color: rgba(255,255,255,0.2); }
+.outline {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid currentColor;
+  box-shadow: none;
+}
+.outline:hover { color: var(--primary-2); border-color: var(--primary-2); }
+.danger { background: var(--danger); box-shadow: 0 12px 24px rgba(255,76,76,0.25); }
+.large { font-size: 1.05rem; padding: 12px 28px; }
+
+.tabs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 6px;
+  background: linear-gradient(135deg, rgba(8,12,32,0.65), rgba(12,18,42,0.4));
+  border: 1px solid var(--border);
+  backdrop-filter: blur(18px);
+  position: sticky;
+  top: 110px;
+  z-index: 3;
+  padding: 6px;
+}
+
+.tab {
+  padding: 14px 12px;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  border-bottom: 3px solid transparent;
+  border-radius: 12px;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+.tab:hover { color: var(--fg); background: rgba(255,255,255,0.04); }
+.tab.active {
+  color: var(--fg);
+  border-color: var(--primary);
+  background: rgba(255,255,255,0.08);
+  box-shadow: inset 0 0 12px rgba(0,0,0,0.25);
+}
+
+main {
+  padding: clamp(24px, 4vw, 40px) 0 clamp(96px, 10vw, 120px);
+  display: grid;
+  gap: clamp(28px, 5vw, 48px);
+  width: 100%;
+  flex: 1 1 auto;
+}
+
+.panel { display: none; }
+.panel.visible { display: block; animation: fadeIn 0.35s ease; }
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 24px;
+  align-items: stretch;
+}
+
+.toolbar > * {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.toolbar button {
+  justify-content: center;
+}
+
+.toolbar .icon,
+.actions .icon,
+.header-actions .icon,
+#custom-data-tools .icon,
+#btn-reset .icon {
+  width: 18px;
+  height: 18px;
+}
+
+select, input[type="text"], input[type="number"] {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--input-border);
+  background: var(--input-surface);
+  color: var(--fg);
+  min-width: 220px;
+  font-size: 0.95rem;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
+}
+
+input::placeholder { color: var(--muted); opacity: 0.78; }
 
 .card {
-  background: linear-gradient(180deg, var(--card), rgba(255,255,255,0.02));
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+  background: linear-gradient(160deg, rgba(255,255,255,0.09) 0%, rgba(12,16,32,0.78) 100%);
+  border: 1px solid var(--card-border);
+  border-radius: 22px;
+  padding: clamp(24px, 4vw, 32px);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
 }
-.card.compact { max-width: 700px; }
+.card.compact { max-width: 720px; }
 
-.prompt { font-size: 24px; font-weight: 700; margin-bottom: 12px; }
-.answer { width: 100%; font-size: 18px; }
-.choices { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; margin: 12px 0; }
+.prompt { font-size: clamp(1.9rem, 1.4rem + 1vw, 2.6rem); font-weight: 700; margin-bottom: 16px; letter-spacing: 0.02em; line-height: 1.35; }
+.answer { width: 100%; font-size: 1.2rem; }
+.prompt-scene { display: flex; flex-direction: column; gap: 14px; margin-bottom: 18px; }
+.prompt-visual { position: relative; width: 100%; border-radius: 20px; overflow: hidden; aspect-ratio: 16 / 9; background: linear-gradient(145deg, rgba(255,255,255,0.08), rgba(0,0,0,0.28)); box-shadow: 0 26px 54px rgba(0,0,0,0.35); --scene-image: none; --scene-accent: var(--primary); }
+.prompt-visual::before { content: ''; position: absolute; inset: 0; background-image: var(--scene-image); background-size: cover; background-position: center; filter: saturate(1.08) brightness(0.98); transform: scale(1.02); transition: transform 0.45s ease; }
+.prompt-visual::after { content: ''; position: absolute; inset: 0; background: linear-gradient(180deg, rgba(0,0,0,0.18), rgba(0,0,0,0.6)), linear-gradient(135deg, rgba(255,255,255,0.05), rgba(0,0,0,0.55)), linear-gradient(135deg, rgba(0,0,0,0), rgba(0,0,0,0.4)), linear-gradient(135deg, rgba(255,255,255,0), var(--scene-accent, rgba(0,0,0,0.45))); mix-blend-mode: multiply; }
+.prompt-visual:hover::before { transform: scale(1.05); }
+.prompt-meta { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.prompt-meta button { flex-shrink: 0; }
+.tag { display: inline-flex; align-items: center; gap: 8px; padding: 0.4rem 0.9rem; border-radius: 999px; text-transform: uppercase; font-weight: 650; letter-spacing: 0.06em; font-size: 0.92rem; border: 1px solid rgba(255,255,255,0.32); color: #fff; box-shadow: 0 12px 28px rgba(0,0,0,0.28); position: relative; background: linear-gradient(135deg, rgba(255,255,255,0.12), rgba(0,0,0,0.22)); z-index: 0; }
+.tag::before { content: ''; position: absolute; inset: 0; border-radius: inherit; background: linear-gradient(135deg, var(--tag-accent, var(--primary)) 0%, rgba(0,0,0,0.25) 100%); opacity: 0.88; z-index: -1; }
+.tag::after { content: ''; position: absolute; inset: 0; border-radius: inherit; background: linear-gradient(135deg, rgba(255,255,255,0.16), transparent); opacity: 0.7; pointer-events: none; }
+.ghost.circle { width: 46px; height: 46px; border-radius: 50%; padding: 0; display: grid; place-items: center; border-width: 1px; }
+.ghost.circle .icon { width: 22px; height: 22px; }
+.choices {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(14px, 2vw, 22px);
+  margin: clamp(18px, 3vw, 28px) 0;
+}
+
 .choice-btn {
-  padding: 10px; border-radius: 10px; border: 1px solid var(--border); background: var(--card); color: var(--fg); cursor: pointer; text-align: left;
+  padding: clamp(16px, 2.6vw, 24px);
+  border-radius: 18px;
+  border: 1px solid var(--input-border);
+  background: var(--input-surface);
+  color: var(--fg);
+  cursor: pointer;
+  text-align: center;
+  font-size: clamp(1.05rem, 0.9rem + 0.6vw, 1.35rem);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 68px;
+  transition: transform 0.18s ease, border-color 0.2s ease, box-shadow 0.18s ease;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), 0 14px 28px rgba(0,0,0,0.22);
 }
-.choice-btn:hover { border-color: var(--primary); }
 
-.actions { display: flex; gap: 8px; }
-.feedback { margin-top: 10px; min-height: 22px; color: var(--muted); }
+.choice-btn:hover {
+  border-color: var(--primary);
+  transform: translateY(-2px);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.1), 0 18px 34px rgba(0,0,0,0.28);
+}
 
-.progress { height: 8px; background: var(--border); border-radius: 6px; margin-top: 14px; overflow: hidden; }
-#bar { height: 8px; background: linear-gradient(90deg, var(--primary), var(--accent)); width: 0%; }
+@media (max-width: 640px) {
+  .choices { grid-template-columns: 1fr; }
+}
+
+.actions { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin-top: 18px; }
+.actions button { min-width: 160px; justify-content: center; }
+.feedback { margin-top: 12px; min-height: 24px; color: var(--muted); font-size: 1rem; letter-spacing: 0.01em; }
+
+.progress { height: 8px; background: var(--border); border-radius: 8px; margin-top: 18px; overflow: hidden; }
+#bar { height: 8px; background: linear-gradient(90deg, var(--primary), var(--accent)); width: 0%; transition: width 0.3s ease; }
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(56px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(62px, 1fr));
+  gap: 12px;
 }
+
 .alpha-item {
+  position: relative;
   background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 10px;
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 14px 10px;
   text-align: center;
-  font-size: 24px;
+  font-size: 1.5rem;
+  box-shadow: 0 12px 24px rgba(0,0,0,0.22);
+  transition: transform 0.2s ease, border-color 0.2s ease;
 }
-.alpha-item small { display: block; color: var(--muted); }
+.alpha-item.selected, .alpha-item:hover { border-color: var(--primary); transform: translateY(-2px); }
+.alpha-item small { display: block; color: var(--muted); font-size: 0.75rem; margin-top: 4px; }
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
 }
 .stat {
   background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 12px;
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 18px;
   text-align: center;
   font-weight: 700;
-  font-size: 24px;
+  font-size: 1.8rem;
+  box-shadow: 0 18px 32px rgba(0,0,0,0.28);
 }
-.stat label { display: block; font-size: 12px; color: var(--muted); font-weight: 500; }
+.stat label { display: block; font-size: 0.8rem; color: var(--muted); font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase; margin-top: 6px; }
 
-.achievements { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 10px; margin-top: 14px; }
+.achievements { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin-top: 18px; }
 .achievement {
-  border: 1px dashed var(--border);
-  border-radius: 12px;
-  padding: 10px;
-  background: rgba(255,255,255,0.02);
-}
-.toggle { display: flex; align-items: center; gap: 8px; margin: 8px 0; }
-
-.app-footer {
-  display: flex; justify-content: space-between; padding: 12px 16px; color: var(--muted);
-  position: sticky; bottom: 0; background: var(--bg);
+  border: 1px dashed var(--input-border);
+  border-radius: 16px;
+  padding: 14px;
+  background: var(--glass);
+  backdrop-filter: blur(12px);
 }
 
-@media (prefers-color-scheme: light) {
-  body:not(.dark) { background: #fff; color: #111; }
+.toggle { display: flex; align-items: center; gap: 10px; margin: 12px 0; cursor: pointer; }
+.toggle input { width: 18px; height: 18px; accent-color: var(--primary); }
+.toggle.inline { margin-top: 0; }
+
+.muted { color: var(--muted); }
+.small { font-size: 0.85rem; }
+.hidden { display: none !important; }
+
+.custom-data-tools { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+
+.landing {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  z-index: 10;
+}
+.landing.visible { display: flex; }
+.landing__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(4,6,14,0.72);
+  backdrop-filter: blur(30px);
+}
+.landing__content {
+  position: relative;
+  width: min(980px, 100% - clamp(24px, 6vw, 80px));
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  padding: clamp(28px, 5vw, 40px);
+  border-radius: 28px;
+  border: 1px solid rgba(255,255,255,0.2);
+  background: linear-gradient(160deg, rgba(255,255,255,0.08), rgba(12,18,38,0.85));
+  box-shadow: 0 45px 80px rgba(0,0,0,0.45);
+}
+.landing__header h1 { margin: 0 0 8px; font-size: clamp(1.8rem, 1.6rem + 0.8vw, 2.4rem); }
+.landing__header p { margin: 0; font-size: 1rem; color: var(--muted); }
+.landing__layout { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: clamp(24px, 5vw, 48px); align-items: start; }
+.landing__hero { display: flex; flex-direction: column; gap: clamp(20px, 4vw, 32px); }
+.landing__section { margin-top: 0; }
+.landing__section h2 { margin-bottom: 16px; font-size: 1.2rem; text-transform: uppercase; letter-spacing: 0.14em; color: var(--muted); }
+.landing__highlights { list-style: none; margin: 0; padding: 0; display: grid; gap: 16px; }
+.landing__highlights li { display: grid; grid-template-columns: auto 1fr; gap: 14px; align-items: center; padding: 14px 18px; border-radius: 20px; border: 1px solid rgba(255,255,255,0.16); background: rgba(12,18,38,0.6); backdrop-filter: blur(14px); box-shadow: 0 12px 28px rgba(0,0,0,0.25); }
+.landing__highlights .icon { width: 28px; height: 28px; color: var(--accent); }
+.landing__panels { display: grid; gap: clamp(20px, 3vw, 32px); align-content: start; }
+.landing__note { margin-top: clamp(24px, 4vw, 36px); display: grid; grid-template-columns: auto 1fr; gap: 14px; align-items: start; padding: 16px 20px; border-radius: 22px; border: 1px solid rgba(255,255,255,0.18); background: rgba(12,18,38,0.68); box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04); color: var(--muted); }
+.landing__note .icon { width: 24px; height: 24px; color: var(--primary); }
+.landing__note p { margin: 0; line-height: 1.5; }
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+}
+.theme-grid.compact { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+
+.theme-card {
+  font: inherit;
+  position: relative;
+  border-radius: 22px;
+  padding: 18px;
+  border: 2px solid transparent;
+  background: var(--theme-bg, rgba(20,24,45,0.8));
+  box-shadow: 0 18px 36px rgba(0,0,0,0.28);
+  cursor: pointer;
+  color: #fff;
+  transition: transform 0.25s ease, border-color 0.2s ease, box-shadow 0.25s ease;
+  min-height: 180px;
+  display: grid;
+  align-content: space-between;
+  gap: 18px;
+  overflow: hidden;
+}
+.theme-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  display: grid;
+  place-items: center;
+  background: rgba(255,255,255,0.16);
+  border: 1px solid rgba(255,255,255,0.32);
+  backdrop-filter: blur(10px);
+  z-index: 2;
+}
+.theme-card__icon .icon { width: 28px; height: 28px; }
+.theme-card__body { display: flex; flex-direction: column; gap: 8px; }
+.theme-card::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  background-image: var(--theme-image, none);
+  background-size: cover;
+  background-position: center;
+  filter: saturate(1.05) contrast(1.05);
+  opacity: 0.75;
+  transform: scale(1.05);
+  z-index: 0;
+}
+.theme-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--theme-overlay, linear-gradient(180deg, transparent 30%, rgba(0,0,0,0.35)));
+  opacity: 0.9;
+  pointer-events: none;
+  z-index: 1;
+}
+.theme-card strong, .theme-card span { position: relative; z-index: 2; }
+.theme-card strong { font-size: 1.1rem; letter-spacing: 0.06em; text-transform: uppercase; }
+.theme-card span { font-size: 0.9rem; color: rgba(255,255,255,0.9); }
+.theme-card:hover { transform: translateY(-4px); box-shadow: 0 28px 60px rgba(0,0,0,0.35); }
+.theme-card.active { border-color: rgba(255,255,255,0.85); box-shadow: 0 32px 68px rgba(0,0,0,0.4); }
+.theme-card.active .theme-card__icon { border-color: rgba(255,255,255,0.88); background: rgba(255,255,255,0.22); }
+.theme-card:focus-visible { outline: 2px solid rgba(255,255,255,0.9); outline-offset: 4px; }
+
+.grade-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 18px;
+}
+.grade-grid.compact { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+
+.grade-card {
+  font: inherit;
+  position: relative;
+  border-radius: 20px;
+  padding: 20px 18px;
+  border: 2px solid rgba(255,255,255,0.18);
+  background: rgba(12,18,38,0.75);
+  box-shadow: 0 18px 36px rgba(0,0,0,0.28);
+  cursor: pointer;
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 18px;
+}
+.grade-card::before {
+  content: "";
+  position: absolute;
+  inset: -40% 50% auto -40%;
+  height: 160%;
+  background: var(--grade-ribbon, radial-gradient(circle at 20% 20%, rgba(255,255,255,0.28), transparent 65%));
+  transform: rotate(8deg);
+  opacity: 0.45;
+}
+.grade-card__icon { position: relative; z-index: 1; width: 52px; height: 52px; border-radius: 18px; display: grid; place-items: center; background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.2); box-shadow: inset 0 0 12px rgba(0,0,0,0.25); }
+.grade-card__icon .icon { width: 28px; height: 28px; color: var(--accent); }
+.grade-card__body { position: relative; z-index: 1; display: flex; flex-direction: column; gap: 6px; }
+.grade-card__body strong { font-size: 1.2rem; }
+.grade-card__body span { color: rgba(255,255,255,0.78); font-size: 0.9rem; line-height: 1.4; }
+.grade-card.active { border-color: var(--primary); transform: translateY(-4px); box-shadow: 0 26px 60px rgba(0,0,0,0.35); }
+.grade-card.active .grade-card__icon { border-color: var(--primary); background: rgba(255,255,255,0.2); }
+.grade-card:focus-visible { outline: 2px solid var(--primary); outline-offset: 4px; }
+
+.achievement { position: relative; overflow: hidden; }
+.achievement strong { display: block; margin-bottom: 8px; font-size: 1rem; }
+.achievement p { margin: 0; font-size: 0.85rem; color: var(--muted); line-height: 1.45; }
+.achievement.unlocked { border-style: solid; background: rgba(255,255,255,0.12); }
+.achievement.unlocked p { color: rgba(255,255,255,0.8); }
+
+.landing-entered body { overflow: auto; }
+
+.dyslexic { letter-spacing: 0.03em; line-height: 1.6; }
+
+p { margin: 0 0 0.8em; }
+
+h1, h2, h3 { line-height: 1.2; }
+
+@media (max-width: 1023px) {
+  .app-footer {
+    margin-top: clamp(36px, 7vw, 56px);
+    border-radius: 18px;
+  }
+  .landing__layout { grid-template-columns: 1fr; }
+  .landing__panels { order: 2; }
+  .landing__hero { order: 1; }
 }
 
-.dyslexic { letter-spacing: 0.02em; line-height: 1.5; }
+@media (max-width: 980px) {
+  :root { --shell-width: 100%; }
+  .app-header { border-radius: 18px; }
+  .tabs { top: 126px; }
+}
+
+@media (min-width: 1024px) {
+  .app-footer { margin-bottom: clamp(32px, 4vw, 48px); }
+}
+
+@media (max-width: 820px) {
+  .tabs {
+    display: flex;
+    overflow-x: auto;
+    gap: 6px;
+    scrollbar-width: none;
+  }
+  .tabs::-webkit-scrollbar { display: none; }
+  .tab { flex: 0 0 auto; min-width: 132px; border-bottom-width: 2px; }
+  .app-header { align-items: flex-start; }
+  .header-actions { width: 100%; justify-content: flex-start; }
+}
+
+@media (max-width: 720px) {
+  .app-shell::before { display: none; }
+  .brand { width: 100%; }
+  .brand__title { white-space: normal; }
+  .btn-label { display: none; }
+  .app-header { padding: 14px 16px; }
+  .tabs { top: 118px; }
+  main { padding-top: clamp(20px, 6vw, 32px); }
+  main select, main input[type="text"], main input[type="number"] { width: 100%; min-width: 0; }
+  main .toolbar { flex-direction: column; align-items: stretch; }
+  main .toolbar button { width: 100%; justify-content: center; }
+  main .primary, main .ghost, main .outline, main .danger { width: 100%; justify-content: center; }
+  .landing__highlights li { grid-template-columns: 1fr; }
+  .landing__note { grid-template-columns: 1fr; text-align: left; }
+  .landing__note .icon { display: none; }
+}
+
+@media (max-width: 560px) {
+  .theme-grid { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+  .grade-grid { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+  .landing { padding: 12px; }
+  .landing__content { padding: 24px; border-radius: 22px; }
+}
+
+@media (max-width: 420px) {
+  .brand__mark { width: 36px; height: 36px; font-size: 0.95rem; }
+  .app-header { gap: 12px; }
+  .tab { min-width: 120px; font-size: 0.85rem; }
+  .achievement { padding: 12px; }
+}
+
+.btn-label { font-size: 0.85rem; }


### PR DESCRIPTION
## Summary
- replace the legacy word lists with themed sentence-based decks backed by curated scene artwork per Dialog grade
- add illustrated prompt scenes, larger typography, and dedicated listen controls to the learn and review views for better readability and audio support
- ensure background music resumes after landing interactions so the ambience accompanies the polished landing experience

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6be95c5a883269f6346ef62ebf0b5